### PR TITLE
Add username and role support

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,9 +1,18 @@
 const mongoose = require("mongoose");
 
-const UserSchema = new mongoose.Schema({
-  login: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  // інші поля за потребою
-}, { timestamps: true });
+const UserSchema = new mongoose.Schema(
+  {
+    login: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    username: { type: String, required: true },
+    role: { type: String, default: "player" },
+    settings: {
+      musicVolume: { type: Number, default: 50 },
+      brightness: { type: Number, default: 50 },
+    },
+    // інші поля за потребою
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model("User", UserSchema);


### PR DESCRIPTION
## Summary
- extend User schema with username, role and settings
- include username in register/login
- return role and username in authentication responses

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68480554d9b08322a5ad01cdb5db4f34