### PR TITLE
Expose username and role to frontend

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,7 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/api/auth", require("./routes/auth"));
+app.use("/api/admin", require("./routes/admin"));
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -18,7 +18,11 @@ exports.register = async (req, res) => {
     }
 
     const hash = await bcrypt.hash(password, 10);
-    const user = new User({ login, password: hash });
+    const user = new User({
+      login,
+      password: hash,
+      username: login,
+    });
     await user.save();
 
     res.status(201).json({ message: "User created" });
@@ -51,7 +55,9 @@ exports.login = async (req, res) => {
       token,
       user: {
         _id: user._id,
-        login: user.login
+        login: user.login,
+        username: user.username,
+        role: user.role,
       }
     });
   } catch (err) {

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -22,3 +22,12 @@ exports.updateSettings = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.getAll = async (req, res) => {
+  try {
+    const users = await User.find().select('-password');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,9 +1,18 @@
 const mongoose = require("mongoose");
 
-const UserSchema = new mongoose.Schema({
-  login: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  // інші поля за потребою
-}, { timestamps: true });
+const UserSchema = new mongoose.Schema(
+  {
+    login: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    username: { type: String },
+    role: {
+      type: String,
+      enum: ["player", "master", "admin"],
+      default: "player",
+    },
+    // інші поля за потребою
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model("User", UserSchema);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const auth = require('../middlewares/authMiddleware');
+
+const onlyMaster = (req, res, next) => {
+  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
+  return res.status(403).json({ message: 'Forbidden' });
+};
+
+router.get('/users', auth, onlyMaster, userController.getAll);
+
+module.exports = router;

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useUserStore } from "../store/user";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from "../api/axios";
 
 export default function AdminPage() {
   const { user } = useUserStore();
@@ -15,8 +15,7 @@ export default function AdminPage() {
     }
     const fetchUsers = async () => {
       try {
-        const apiUrl = import.meta.env.VITE_API_URL || "";
-        const res = await axios.get(`${apiUrl}/api/admin/users`);
+        const res = await api.get("/admin/users");
         setUsers(res.data);
       } catch (e) {}
     };


### PR DESCRIPTION
## Summary
- extend User schema with `username` and `role`
- include `username` and `role` when registering and logging in
- expose endpoint `/api/admin/users` to list all users
- serve the admin routes from Express app
- update AdminPage to fetch users with auth token

## Testing
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68480556d0b0832290881291d04acc8d