### PR TITLE
Add socket.io server and env based frontend connection

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const cors = require("cors");
 const mongoose = require("mongoose");
+const http = require("http");
+const socket = require("./socket");
 
 const app = express();
 app.use(cors());
@@ -14,7 +16,10 @@ const MONGO_URI = process.env.MONGO_URI;
 mongoose.connect(MONGO_URI)
   .then(() => {
     console.log("MongoDB connected");
-    app.listen(PORT, () => {
+    const server = http.createServer(app);
+    const io = socket.init(server);
+    app.set("io", io);
+    server.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });
   })

--- a/backend/src/controllers/rollController.js
+++ b/backend/src/controllers/rollController.js
@@ -17,13 +17,18 @@ exports.create = async (req, res) => {
       session
     });
     await roll.save();
-    // Якщо isPrivate — тільки майстер отримує результат
-    res.json({
+    const result = {
       value: isPrivate ? null : value,
       roller: req.user.id,
       diceType,
       id: roll._id
-    });
+    };
+    const io = req.app.get('io');
+    if (io && session) {
+      io.to(session).emit('dice-roll', result);
+    }
+    // Якщо isPrivate — тільки майстер отримує результат
+    res.json(result);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -1,0 +1,141 @@
+const { Server } = require('socket.io');
+
+let io;
+const sessions = {};
+
+function getSession(id) {
+  if (!sessions[id]) {
+    sessions[id] = {
+      gm: null,
+      players: [],
+      monsters: [],
+      initiative: [],
+      map: '',
+      chat: [],
+      state: 'lobby'
+    };
+  }
+  return sessions[id];
+}
+
+function init(httpServer) {
+  io = new Server(httpServer, {
+    cors: { origin: '*' }
+  });
+
+  io.on('connection', (socket) => {
+    socket.on('join-lobby', ({ tableId, user }) => {
+      if (!tableId || !user) return;
+      const sess = getSession(tableId);
+      socket.join(tableId);
+      socket.data.tableId = tableId;
+      socket.data.userId = user._id;
+      let player = sess.players.find(p => p.user === user._id);
+      if (!player) {
+        player = { user: user._id, name: user.username || user.login, online: true };
+        sess.players.push(player);
+      } else {
+        player.online = true;
+      }
+      if (!sess.gm) {
+        sess.gm = user._id;
+        socket.emit('gm-assigned');
+      }
+      io.to(tableId).emit('lobby-players', { players: sess.players });
+    });
+
+    socket.on('start-game', ({ tableId }) => {
+      const sess = getSession(tableId);
+      sess.state = 'active';
+      io.to(tableId).emit('game-started');
+    });
+
+    socket.on('join-table', ({ tableId, user }) => {
+      if (!tableId || !user) return;
+      const sess = getSession(tableId);
+      socket.join(tableId);
+      socket.data.tableId = tableId;
+      socket.data.userId = user._id;
+      let player = sess.players.find(p => p.user === user._id);
+      if (!player) {
+        player = { user: user._id, name: user.username || user.login, online: true };
+        sess.players.push(player);
+      } else {
+        player.online = true;
+      }
+      socket.emit('chat-history', sess.chat);
+      io.to(tableId).emit('table-players', {
+        players: sess.players,
+        gm: sess.gm,
+        monsters: sess.monsters,
+        initiative: sess.initiative
+      });
+      if (sess.map) socket.emit('map-update', sess.map);
+    });
+
+    socket.on('monster-add', ({ tableId, monster }) => {
+      const sess = getSession(tableId);
+      sess.monsters.push(monster);
+      io.to(tableId).emit('monsters-update', sess.monsters);
+    });
+
+    socket.on('monster-remove', ({ tableId, idx }) => {
+      const sess = getSession(tableId);
+      if (sess.monsters[idx]) sess.monsters.splice(idx, 1);
+      io.to(tableId).emit('monsters-update', sess.monsters);
+    });
+
+    socket.on('initiative-start', ({ tableId, items }) => {
+      const sess = getSession(tableId);
+      sess.initiative = items || [];
+      io.to(tableId).emit('initiative-update', sess.initiative);
+    });
+
+    socket.on('map-update', ({ tableId, map }) => {
+      const sess = getSession(tableId);
+      sess.map = map;
+      io.to(tableId).emit('map-update', sess.map);
+    });
+
+    socket.on('kick-player', ({ tableId, userId }) => {
+      const sess = getSession(tableId);
+      sess.players = sess.players.filter(p => p.user !== userId);
+      io.to(tableId).emit('table-players', {
+        players: sess.players,
+        gm: sess.gm,
+        monsters: sess.monsters,
+        initiative: sess.initiative
+      });
+    });
+
+    socket.on('chat-message', ({ tableId, user, text }) => {
+      const sess = getSession(tableId);
+      const msg = { user: user.username || user.login, text, timestamp: Date.now() };
+      sess.chat.push(msg);
+      io.to(tableId).emit('chat-message', msg);
+    });
+
+    socket.on('disconnect', () => {
+      const { tableId, userId } = socket.data;
+      if (!tableId || !userId) return;
+      const sess = getSession(tableId);
+      const player = sess.players.find(p => p.user === userId);
+      if (player) {
+        player.online = false;
+        const event = sess.state === 'lobby' ? 'lobby-players' : 'table-players';
+        const payload = event === 'lobby-players'
+          ? { players: sess.players }
+          : { players: sess.players, gm: sess.gm, monsters: sess.monsters, initiative: sess.initiative };
+        io.to(tableId).emit(event, payload);
+      }
+    });
+  });
+
+  return io;
+}
+
+function getIO() {
+  return io;
+}
+
+module.exports = { init, getIO };

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -11,7 +11,7 @@ export default function ChatBox({ sessionId }) {
   const chatEnd = useRef();
 
   useEffect(() => {
-    socket = io('/', {
+    socket = io(import.meta.env.VITE_SOCKET_URL || '/', {
       auth: { token },
       query: { sessionId },
     });

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -8,8 +8,8 @@ import MonstersList from "../components/MonstersList";
 import ChatComponent from "../components/ChatComponent";
 import PlayerCard from "../components/PlayerCard";
 
-// !!! ВАЖЛИВО: якщо бек локально — зміни на своє посилання
-const socket = io("https://d-dua.onrender.com");
+// socket connection URL configurable via env
+const socket = io(import.meta.env.VITE_SOCKET_URL);
 
 export default function GameTablePage() {
   const { user } = useUserStore();

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { io } from "socket.io-client";
-const socket = io("https://d-dua.onrender.com"); // <-- твій бекенд
+const socket = io(import.meta.env.VITE_SOCKET_URL);
 
 export default function LobbyPage({ tableId, user }) {
   const [players, setPlayers] = useState([]);


### PR DESCRIPTION
## Summary
- integrate socket.io with Express server
- implement real-time lobby and table events
- emit dice results from roll controller
- read socket URL from `VITE_SOCKET_URL` on frontend

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68480558e1cc8322b79269b72daf0fcc