### PR TITLE
Implement user settings endpoint

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,7 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/api/auth", require("./routes/auth"));
+app.use("/api/user", require("./routes/userSettings"));
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -12,12 +12,18 @@ exports.me = async (req, res) => {
 exports.updateSettings = async (req, res) => {
   try {
     const { musicVolume, brightness } = req.body;
+
+    const update = {};
+    if (musicVolume !== undefined) update['settings.musicVolume'] = musicVolume;
+    if (brightness !== undefined) update['settings.brightness'] = brightness;
+
     const user = await User.findByIdAndUpdate(
       req.user.id,
-      { $set: { 'settings.musicVolume': musicVolume, 'settings.brightness': brightness } },
+      { $set: update },
       { new: true }
     ).select('-password');
-    res.json(user);
+
+    res.json(user.settings);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,9 +1,16 @@
 const mongoose = require("mongoose");
 
-const UserSchema = new mongoose.Schema({
-  login: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  // інші поля за потребою
-}, { timestamps: true });
+const UserSchema = new mongoose.Schema(
+  {
+    login: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    settings: {
+      musicVolume: { type: Number, default: 50 },
+      brightness: { type: Number, default: 50 },
+    },
+    // інші поля за потребою
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model("User", UserSchema);

--- a/backend/src/routes/userSettings.js
+++ b/backend/src/routes/userSettings.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middlewares/authMiddleware');
+const userController = require('../controllers/userController');
+
+router.get('/me', auth, userController.me);
+router.put('/settings', auth, userController.updateSettings);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- extend `User` schema with `settings.musicVolume` and `settings.brightness`
- allow partial updates of settings in `updateSettings`
- add `userSettings` routes with `/me` and `/settings`
- expose the new user routes from Express app

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848055535708322a2c900f8b8ae7e1e