### PR TITLE
Fix Jest version for backend tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,7 @@
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
-    "jest": "^30.0.0",
+    "jest": "^29.7.0",
     "nodemon": "^3.1.0",
     "supertest": "^7.1.1"
   },


### PR DESCRIPTION
## Summary
- set Jest dev dependency to `^29.7.0`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848110fe77c8322800324096752ae5d