### PR TITLE
Fix admin token usage

### DIFF
--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 export default function AdminPage() {
-  const { user } = useUserStore();
+  const { user, token } = useUserStore();
   const navigate = useNavigate();
   const [users, setUsers] = useState([]);
 
@@ -16,7 +16,9 @@ export default function AdminPage() {
     const fetchUsers = async () => {
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const res = await axios.get(`${apiUrl}/api/admin/users`);
+        const res = await axios.get(`${apiUrl}/api/admin/users`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         setUsers(res.data);
       } catch (e) {}
     };

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -6,18 +6,19 @@ export const useUserStore = create(
   persist(
     (set) => ({
       user: null,
+      token: null,
       setUser: (user, token) => {
         localStorage.setItem("token", token);
-        set({ user });
+        set({ user, token });
       },
       logout: () => {
         localStorage.removeItem("token");
-        set({ user: null });
+        set({ user: null, token: null });
       },
     }),
     {
       name: "user-storage",
-      partialize: (state) => ({ user: state.user }),
+      partialize: (state) => ({ user: state.user, token: state.token }),
     }
   )
 );


### PR DESCRIPTION
## Summary
- persist auth token in the user store so admin pages can access it
- send Authorization header from AdminPage when listing users

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684811139fc08322a34544a3c7e5be94