### PR TITLE
Add inventory generation and hp validation

### DIFF
--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -1,0 +1,38 @@
+const characterController = require('../src/controllers/characterController');
+const Race = require('../src/models/Race');
+const Profession = require('../src/models/Profession');
+const Characteristic = require('../src/models/Characteristic');
+const Character = require('../src/models/Character');
+
+jest.mock('../src/models/Race');
+jest.mock('../src/models/Profession');
+jest.mock('../src/models/Characteristic');
+jest.mock('../src/models/Character');
+
+describe('Character Controller - create', () => {
+  it('populates inventory and validates wizard hp range', async () => {
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard' }]);
+    Characteristic.find.mockResolvedValue([
+      { _id: 'c1', name: 'hp' },
+      { _id: 'c2', name: 'mp' },
+    ]);
+    let savedData;
+    Character.mockImplementation(data => {
+      savedData = data;
+      return { save: jest.fn().mockResolvedValue(data) };
+    });
+
+    const req = { user: { id: 'u1' }, body: { name: 'Hero', description: '', image: '' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(savedData.inventory.length).toBeGreaterThanOrEqual(2);
+    const hp = savedData.stats.find(s => s.characteristic === 'c1').value;
+    expect(hp).toBeGreaterThanOrEqual(6);
+    expect(hp).toBeLessThanOrEqual(10);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add helper functions for generating character inventory
- validate hp values by profession during character creation
- create tests for new logic in character controller

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684815de60508322a29dd4f1ed2df60c