### PR TITLE
Enable dotenv and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index 0bfd324f2965dad5edfe46d5958ccbd85003cb64..4758674b85d8a40b450a9f825c8bbb89066787fd 100644
---- a/README.md
-+++ b/README.md
-@@ -1,2 +1,6 @@
- # D-DUA
- D-DUA
-+
-+The backend automatically creates `uploads/` and `uploads/maps/` directories on
-+startup to store uploaded images. Files placed there are served from the
-+`/uploads` path.
- 
-EOF
-)
+# D-DUA
+D-DUA
+
+The backend automatically creates `uploads/` and `uploads/maps/` directories on startup to store uploaded images. Files placed there are served from the `/uploads` path.
+
+## Environment variables
+
+Create a `.env` file inside `backend` with the following values:
+
+- `MONGO_URI` – MongoDB connection string.
+- `JWT_SECRET` – secret key for signing JWT tokens.
+- `OPENAI_API_KEY` – API key for image and description generation.
+- `PORT` – optional port for the server (defaults to `5000`).
+

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');


### PR DESCRIPTION
## Summary
- load environment variables in backend app
- clean up README and list necessary environment variables

## Testing
- `npm install --prefix backend` *(fails: 403 Forbidden)*
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684815df07408322ae78bbee7ac661db