### PR TITLE
Extend user store to persist token

### DIFF
--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -6,18 +6,19 @@ export const useUserStore = create(
   persist(
     (set) => ({
       user: null,
+      token: null,
       setUser: (user, token) => {
         localStorage.setItem("token", token);
-        set({ user });
+        set({ user, token });
       },
       logout: () => {
         localStorage.removeItem("token");
-        set({ user: null });
+        set({ user: null, token: null });
       },
     }),
     {
       name: "user-storage",
-      partialize: (state) => ({ user: state.user }),
+      partialize: (state) => ({ user: state.user, token: state.token }),
     }
   )
 );


### PR DESCRIPTION
## Summary
- store JWT token in the Zustand `useUserStore`
- persist both user and token

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684881c5b5708322bdd0402e8723fa22