### PR TITLE
Remove unused import from axios

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,6 +1,5 @@
 
 import axios from "axios";
-import { useUserStore } from "../store/user";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,


### PR DESCRIPTION
## Summary
- remove leftover useUserStore import

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684881c692c4832280de537d429176e4