### PR TITLE
Remove stray lines from character pages

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -43,7 +43,6 @@ export default function CharacterCreatePage() {
 
 
       const res = await api.post("/api/character", {
- main
         name,
         bio,
         race,

--- a/frontend/src/pages/CharacterEditPage.jsx
+++ b/frontend/src/pages/CharacterEditPage.jsx
@@ -13,7 +13,6 @@ export default function CharacterEditPage() {
   useEffect(() => {
 
     api.get(`/api/character/${id}`)
- main
       .then(res => {
         setCharacter(res.data);
         setName(res.data.name || "");
@@ -28,7 +27,6 @@ export default function CharacterEditPage() {
     try {
 
       await api.put(`/api/character/${id}`, { name, description });
- main
       navigate("/characters");
     } catch (err) {
       setError("Не вдалося зберегти зміни");

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -8,7 +8,6 @@ export default function CharacterListPage() {
   useEffect(() => {
 
     api.get("/api/character")
- main
       .then(res => setCharacters(res.data))
       .catch(() => setCharacters([]));
   }, []);


### PR DESCRIPTION
## Summary
- fix leftover 'main' lines after API calls in character pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684889820be48322b3a3239091954c30