### PR TITLE
Fix admin API endpoints

### DIFF
--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -12,7 +12,7 @@ export default function AdminCharacteristicsPage() {
 
   const fetchCharacteristics = async () => {
     setLoading(true);
-    const res = await axios.get('/api/characteristics', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await axios.get('/api/characteristic', { headers: { Authorization: `Bearer ${token}` } });
     setCharacteristics(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminCharacteristicsPage() {
 
   const addCharacteristic = async (e) => {
     e.preventDefault();
-    await axios.post('/api/characteristics', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.post('/api/characteristic', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchCharacteristics();
   };
 
   const removeCharacteristic = async (id) => {
-    await axios.delete(`/api/characteristics/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.delete(`/api/characteristic/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchCharacteristics();
   };
 

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -13,7 +13,7 @@ export default function AdminMapsPage() {
 
   const fetchMaps = async () => {
     setLoading(true);
-    const res = await axios.get('/api/maps', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await axios.get('/api/map', { headers: { Authorization: `Bearer ${token}` } });
     setMaps(res.data);
     setLoading(false);
   };
@@ -25,14 +25,14 @@ export default function AdminMapsPage() {
     const formData = new FormData();
     formData.append('name', name);
     formData.append('image', file);
-    await axios.post('/api/maps', formData, {
+    await axios.post('/api/map', formData, {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' },
     });
     setName(''); setFile(null); fileInput.current.value = null; fetchMaps();
   };
 
   const removeMap = async (id) => {
-    await axios.delete(`/api/maps/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.delete(`/api/map/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchMaps();
   };
 

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -12,7 +12,7 @@ export default function AdminProfessionsPage() {
 
   const fetchProfessions = async () => {
     setLoading(true);
-    const res = await axios.get('/api/professions', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await axios.get('/api/profession', { headers: { Authorization: `Bearer ${token}` } });
     setProfessions(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminProfessionsPage() {
 
   const addProfession = async (e) => {
     e.preventDefault();
-    await axios.post('/api/professions', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.post('/api/profession', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchProfessions();
   };
 
   const removeProfession = async (id) => {
-    await axios.delete(`/api/professions/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.delete(`/api/profession/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchProfessions();
   };
 

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -12,7 +12,7 @@ export default function AdminRacesPage() {
 
   const fetchRaces = async () => {
     setLoading(true);
-    const res = await axios.get('/api/races', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await axios.get('/api/race', { headers: { Authorization: `Bearer ${token}` } });
     setRaces(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminRacesPage() {
 
   const addRace = async (e) => {
     e.preventDefault();
-    await axios.post('/api/races', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.post('/api/race', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchRaces();
   };
 
   const removeRace = async (id) => {
-    await axios.delete(`/api/races/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await axios.delete(`/api/race/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchRaces();
   };
 


### PR DESCRIPTION
## Summary
- update admin pages to use `/api/race`, `/api/profession`, `/api/characteristic`, `/api/map`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488985584883229a863c6d9fa02b18