### PR TITLE
Integrate socket.io with HTTP server

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const mongoose = require('mongoose');
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
 
 const app = express();
 app.use(cors());
@@ -36,7 +37,10 @@ const MONGO_URI = process.env.MONGO_URI;
 mongoose.connect(MONGO_URI)
   .then(() => {
     console.log('MongoDB connected');
-    app.listen(PORT, () => {
+    const server = http.createServer(app);
+    const io = require('./socket').init(server);
+    app.set('io', io);
+    server.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });
   })


### PR DESCRIPTION
## Summary
- create HTTP server in `app.js` and initialize socket.io

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488a01bcc8832288eb44b718bfdc8f