### PR TITLE
Add admin user list endpoint

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -29,6 +29,7 @@ app.use('/api/race', require('./routes/race'));
 app.use('/api/roll', require('./routes/roll'));
 app.use('/api/session', require('./routes/session'));
 app.use('/api/user', require('./routes/user'));
+app.use('/api/admin', require('./routes/admin'));
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,10 @@
+const User = require('../models/User');
+
+exports.getUsers = async (req, res) => {
+  try {
+    const users = await User.find().select('-password');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const adminController = require('../controllers/adminController');
+const auth = require('../middlewares/authMiddleware');
+const onlyMaster = require('../middlewares/onlyMaster');
+
+router.get('/users', auth, onlyMaster, adminController.getUsers);
+
+module.exports = router;

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 export default function AdminPage() {
-  const { user } = useUserStore();
+  const { user, token } = useUserStore();
   const navigate = useNavigate();
   const [users, setUsers] = useState([]);
 
@@ -16,7 +16,9 @@ export default function AdminPage() {
     const fetchUsers = async () => {
       try {
         const apiUrl = import.meta.env.VITE_API_URL || "";
-        const res = await axios.get(`${apiUrl}/api/admin/users`);
+        const res = await axios.get(`${apiUrl}/api/admin/users`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
         setUsers(res.data);
       } catch (e) {}
     };


### PR DESCRIPTION
## Summary
- expose `/api/admin/users` route
- add controller logic for listing users without passwords
- mount new admin routes in the backend app
- update `AdminPage` to send auth token when fetching users

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488a15e5988322b87738c41f1153d8