### PR TITLE
Enable AI route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -29,6 +29,7 @@ app.use('/api/race', require('./routes/race'));
 app.use('/api/roll', require('./routes/roll'));
 app.use('/api/session', require('./routes/session'));
 app.use('/api/user', require('./routes/user'));
+app.use('/api/ai', require('./routes/ai'));
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;

--- a/backend/tests/ai.test.js
+++ b/backend/tests/ai.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/utils/ai', () => ({
+  generateCharacterImage: jest.fn().mockResolvedValue('http://image.test/avatar.png')
+}));
+
+const aiRouter = require('../src/routes/ai');
+
+const app = express();
+app.use(express.json());
+app.use('/api/ai', aiRouter);
+
+describe('AI Routes', () => {
+  describe('POST /api/ai/avatar', () => {
+    it('should return generated image url', async () => {
+      const res = await request(app).post('/api/ai/avatar').send({ description: 'hero' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body.url).toBe('http://image.test/avatar.png');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expose AI route from app
- add tests for generating avatars

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488afc87a88322ba3d0f758e852d2f