### PR TITLE
Remove stray call causing ReferenceError

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -32,7 +32,6 @@ app.use('/api/session', require('./routes/session'));
 app.use('/api/user', require('./routes/user'));
 
 app.use('/api/ai', require('./routes/ai'));
- main
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;


### PR DESCRIPTION
## Summary
- clean up server bootstrap

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `node src/app.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68488d60802c8322b5335fbc21b61fab