### PR TITLE
Fix missing context imports

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,9 @@
 import "./i18n";
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { SettingsProvider } from './context/SettingsContext';
+import { ToastProvider } from './context/ToastContext';
 import App from './App';
 import './index.css';
 


### PR DESCRIPTION
## Summary
- add BrowserRouter, SettingsProvider, and ToastProvider imports in `frontend/src/main.jsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa5d79c08322905e53adec41f180