### PR TITLE
Fix missing React imports in context files

### DIFF
--- a/frontend/src/context/SettingsContext.jsx
+++ b/frontend/src/context/SettingsContext.jsx
@@ -1,3 +1,4 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
 
 const SettingsContext = createContext();
 

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,3 +1,4 @@
+import React, { createContext, useState, useContext } from 'react';
 
 const ToastContext = createContext();
 


### PR DESCRIPTION
## Summary
- add React hook imports to SettingsContext
- add React hook imports to ToastContext

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aacc7725c83229f13f6cb0bc1fe72