### PR TITLE
Fix React imports across frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ProfilePage from './pages/ProfilePage';

--- a/frontend/src/PrivateRoute.jsx
+++ b/frontend/src/PrivateRoute.jsx
@@ -1,4 +1,7 @@
 
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
 function PrivateRoute({ children }) {
   const token = localStorage.getItem("token");
 

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,4 +1,5 @@
 
+import React, { useState, useEffect, useRef } from 'react';
 import { io } from "socket.io-client";
 
 let socket;

--- a/frontend/src/components/ChatComponent.jsx
+++ b/frontend/src/components/ChatComponent.jsx
@@ -1,4 +1,6 @@
 
+import React, { useState, useEffect, useRef } from 'react';
+
 export default function ChatComponent({ tableId, user, messages, socket }) {
   const [input, setInput] = useState("");
   const chatEnd = useRef(null);

--- a/frontend/src/components/DiceRoller.jsx
+++ b/frontend/src/components/DiceRoller.jsx
@@ -1,8 +1,9 @@
+import React, { useState } from 'react';
 import api from "../api/axios";
 
 const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
 
-export default function DiceRoller({ sessionId, isMaster ) {
+export default function DiceRoller({ sessionId, isMaster }) {
   const [rolling, setRolling] = useState(false);
   const [lastRoll, setLastRoll] = useState(null);
   const { token } = useUserStore();

--- a/frontend/src/components/DiceTable.jsx
+++ b/frontend/src/components/DiceTable.jsx
@@ -1,7 +1,9 @@
 
+import React, { useState } from 'react';
+
 const diceTypes = ["d4", "d6", "d8", "d10", "d12", "d20"];
 
-export default function DiceTable({ isMaster ) {
+export default function DiceTable({ isMaster }) {
   const [lastRoll, setLastRoll] = useState(null);
 
   const roll = (type) => {

--- a/frontend/src/components/GMPanel.jsx
+++ b/frontend/src/components/GMPanel.jsx
@@ -1,4 +1,6 @@
 
+import React, { useState } from 'react';
+
 export default function GMPanel({ tableId, socket, players }) {
   const [monsterName, setMonsterName] = useState("");
   const [mapUrl, setMapUrl] = useState("");

--- a/frontend/src/components/InventoryEditor.jsx
+++ b/frontend/src/components/InventoryEditor.jsx
@@ -1,5 +1,7 @@
 
-export default function InventoryEditor({ inventory, onChange ) {
+import React, { useState } from 'react';
+
+export default function InventoryEditor({ inventory, onChange }) {
   const [items, setItems] = useState(Array.isArray(inventory) ? inventory : []);
   const [input, setInput] = useState('');
 

--- a/frontend/src/components/LogoutButton.jsx
+++ b/frontend/src/components/LogoutButton.jsx
@@ -1,4 +1,7 @@
 
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
 function LogoutButton() {
   const navigate = useNavigate();
 

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from 'react';
 import ReactPlayer from 'react-player';
 import api from '../api/axios';
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import LanguageSwitch from './LanguageSwitch';
 
 function Navbar() {

--- a/frontend/src/context/SettingsContext.jsx
+++ b/frontend/src/context/SettingsContext.jsx
@@ -1,4 +1,6 @@
 
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
 const SettingsContext = createContext();
 
 export function SettingsProvider({ children }) {

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,4 +1,6 @@
 
+import React, { createContext, useContext, useState } from 'react';
+
 const ToastContext = createContext();
 
 export function ToastProvider({ children }) {

--- a/frontend/src/pages/ChangePasswordPage.jsx
+++ b/frontend/src/pages/ChangePasswordPage.jsx
@@ -1,4 +1,6 @@
+import React, { useState } from 'react';
 import axios from "axios";
+import { useNavigate } from 'react-router-dom';
 import Navbar from "../components/Navbar";
 
 function ChangePasswordPage() {

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from "../api/axios";
 
 export default function CharacterCreatePage() {

--- a/frontend/src/pages/CharacterEditPage.jsx
+++ b/frontend/src/pages/CharacterEditPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import api from "../api/axios";
 
 export default function CharacterEditPage() {

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -1,4 +1,5 @@
-import React;
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from "../api/axios";
 
 export default function CharacterListPage() {

--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -1,4 +1,8 @@
 
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createCharacter } from '../utils/api';
+
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import GMPanel from "../components/GMPanel";
 import InitiativeList from "../components/InitiativeList";
 import MonstersList from "../components/MonstersList";

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { io } from "socket.io-client";
 
 const socket = io(import.meta.env.VITE_SOCKET_URL);

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,7 @@
 
 
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import api from "../api/axios";
 
 function LoginPage() {

--- a/frontend/src/pages/MusicControl.jsx
+++ b/frontend/src/pages/MusicControl.jsx
@@ -1,4 +1,6 @@
 
+import React, { useRef } from 'react';
+
 export default function MusicControl() {
   const ref = useRef();
 

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,4 +1,7 @@
 
+import React from 'react';
+import { Link } from 'react-router-dom';
+
 export default function NotFoundPage() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-black text-white font-dnd">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,4 +1,8 @@
 
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getCharacters, deleteCharacter } from '../utils/api';
+
 const ProfilePage = () => {
   const [characters, setCharacters] = useState([]);
   const navigate = useNavigate();

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,4 +1,6 @@
 
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from "axios";
 
 function RegisterPage() {

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 export default function AdminCharacteristicsPage() {

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 export default function AdminMapsPage() {

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 export default function AdminMusicPage() {

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 export default function AdminProfessionsPage() {

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 export default function AdminRacesPage() {


### PR DESCRIPTION
## Summary
- add missing React/hook/router imports in various components and pages
- ensure React hooks work correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aacc939548322b626b79b5ab31b73