### PR TITLE
Fix login page validation

### DIFF
--- a/frontend/src/context/SettingsContext.jsx
+++ b/frontend/src/context/SettingsContext.jsx
@@ -1,5 +1,3 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
-
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
 const SettingsContext = createContext();

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,5 +1,3 @@
-import React, { createContext, useState, useContext } from 'react';
-
 import React, { createContext, useContext, useState } from 'react';
 
 const ToastContext = createContext();

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -16,7 +16,7 @@ function LoginPage() {
 
   const handleSubmit = async (e) => {
     setError(null);
-    if (!email || !password) {
+    if (!login || !password) {
       showToast(t('fields_required'), "error");
       return;
     }


### PR DESCRIPTION
## Summary
- validate login instead of email on login page
- fix duplicate imports that caused frontend build errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ab06b823083228b424ed18e78c1d6