### PR TITLE
Add missing hook imports

### DIFF
--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { io } from "socket.io-client";
+import { useUserStore } from '../store/user';
 
 let socket;
 

--- a/frontend/src/components/DiceRoller.jsx
+++ b/frontend/src/components/DiceRoller.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import api from "../api/axios";
+import { useUserStore } from '../store/user';
 
 const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
 

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactPlayer from 'react-player';
 import api from '../api/axios';
+import { useUserStore } from '../store/user';
 
 export default function MusicPlayer({ isGM }) {
   const { token } = useUserStore();

--- a/frontend/src/context/SettingsContext.jsx
+++ b/frontend/src/context/SettingsContext.jsx
@@ -1,5 +1,3 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
-
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
 const SettingsContext = createContext();

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,5 +1,3 @@
-import React, { createContext, useState, useContext } from 'react';
-
 import React, { createContext, useContext, useState } from 'react';
 
 const ToastContext = createContext();

--- a/frontend/src/pages/CharactersPage.jsx
+++ b/frontend/src/pages/CharactersPage.jsx
@@ -1,4 +1,6 @@
 
+import { useUserStore } from '../store/user';
+
 export default function CharactersPage() {
   const { user } = useUserStore();
 

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -7,6 +7,7 @@ import ChatComponent from "../components/ChatComponent";
 import PlayerCard from "../components/PlayerCard";
 import MusicPlayer from "../components/MusicPlayer";
 import { io } from "socket.io-client";
+import { useUserStore } from '../store/user';
 
 // socket connection URL configurable via env
 const socket = io(import.meta.env.VITE_SOCKET_URL);

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -3,6 +3,10 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import api from "../api/axios";
+import { useToast } from '../context/ToastContext';
+import { useSettings } from '../context/SettingsContext';
+import { useUserStore } from '../store/user';
+import { useTranslation } from 'react-i18next';
 
 function LoginPage() {
   const [login, setLogin] = useState("");

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -1,4 +1,6 @@
 
+import { useUserStore } from '../store/user';
+
 export default function MainPage() {
   const { user } = useUserStore();
 

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -2,6 +2,8 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from "axios";
+import { useToast } from '../context/ToastContext';
+import { useTranslation } from 'react-i18next';
 
 function RegisterPage() {
   const [login, setLogin] = useState("");

--- a/frontend/src/pages/SettingsPanel.jsx
+++ b/frontend/src/pages/SettingsPanel.jsx
@@ -1,4 +1,6 @@
 
+import { useSettings } from '../context/SettingsContext';
+
 export default function SettingsPanel() {
   const { brightness, setBrightness, volume, setVolume, language, setLanguage } = useSettings();
 

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useUserStore } from '../../store/user';
 
 export default function AdminCharacteristicsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useUserStore } from '../../store/user';
 
 export default function AdminMapsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useUserStore } from '../../store/user';
 
 export default function AdminMusicPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useUserStore } from '../../store/user';
 
 export default function AdminProfessionsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useUserStore } from '../../store/user';
 
 export default function AdminRacesPage() {
   const { token } = useUserStore();


### PR DESCRIPTION
## Summary
- add missing hooks for toast, settings, translation, and user store
- clean duplicated imports in context files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ab069a0a083228f3d25491fce5d75