### PR TITLE
Configure CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project combines an Express/MongoDB backend with a React frontend.
    - `JWT_SECRET` – secret used for signing tokens
    - `OPENAI_API_KEY` – API key for generating images and descriptions
    - `PORT` – optional server port (defaults to `5000`)
+   - `CLIENT_URL` – allowed origin for CORS (defaults to `http://localhost:5173`)
 
    Create a `.env` file inside `frontend` with the following keys:
    - `VITE_API_URL` – base URL of the backend API (e.g. `http://localhost:5000/api`)

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,7 +9,11 @@ const http = require('http');
 const app = express();
 const statsRoutes = require("./routes/stats");
 const settingsRoutes = require("./routes/settings");
-app.use(cors());
+const corsOptions = {
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  credentials: true,
+};
+app.use(cors(corsOptions));
 app.use(express.json());
 
 // Ensure uploads directories exist

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -1,5 +1,10 @@
 const { Server } = require('socket.io');
 
+const corsOptions = {
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  credentials: true,
+};
+
 let io;
 const sessions = {};
 
@@ -19,9 +24,7 @@ function getSession(id) {
 }
 
 function init(httpServer) {
-  io = new Server(httpServer, {
-    cors: { origin: '*' }
-  });
+  io = new Server(httpServer, { cors: corsOptions });
 
   io.on('connection', (socket) => {
     socket.on('join-lobby', ({ tableId, user }) => {


### PR DESCRIPTION
## Summary
- allow configurable origin for backend CORS middleware
- apply the same CORS options to socket.io server
- document new `CLIENT_URL` environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab7545fd88322a59c48a5af9bdcf6