### PR TITLE
Improve CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This project combines an Express/MongoDB backend with a React frontend.
    ```
 
 2. **Environment variables**
-   Create a `.env` file inside `backend` with the following keys:
+   Copy `backend/.env.example` to `backend/.env` and adjust the values:
    - `MONGO_URI` – MongoDB connection string
    - `JWT_SECRET` – secret used for signing tokens
    - `OPENAI_API_KEY` – API key for generating images and descriptions
    - `PORT` – optional server port (defaults to `5000`)
-   - `CLIENT_URL` – allowed origin for CORS (defaults to `http://localhost:5173`)
+   - `CLIENT_URL` – allowed origin(s) for CORS. Set this to the URL of your frontend (comma separated to allow multiple, e.g. `http://localhost:5173,https://example.com`).
 
    Create a `.env` file inside `frontend` with the following keys:
    - `VITE_API_URL` – base URL of the backend API (e.g. `http://localhost:5000/api`)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+MONGO_URI=mongodb://localhost:27017/ddua
+JWT_SECRET=your_jwt_secret
+OPENAI_API_KEY=your_openai_api_key
+PORT=5000
+CLIENT_URL=http://localhost:5173

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,8 +9,17 @@ const http = require('http');
 const app = express();
 const statsRoutes = require("./routes/stats");
 const settingsRoutes = require("./routes/settings");
+const allowedOrigins = process.env.CLIENT_URL
+  ? process.env.CLIENT_URL.split(',').map(o => o.trim())
+  : ['http://localhost:5173'];
 const corsOptions = {
-  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   credentials: true,
 };
 app.use(cors(corsOptions));

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -1,7 +1,16 @@
 const { Server } = require('socket.io');
 
+const allowedOrigins = process.env.CLIENT_URL
+  ? process.env.CLIENT_URL.split(',').map(o => o.trim())
+  : ['http://localhost:5173'];
 const corsOptions = {
-  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   credentials: true,
 };
 


### PR DESCRIPTION
## Summary
- add `.env.example` template with CLIENT_URL
- clarify env variable setup in README
- allow multiple origins for CORS in Express app and Socket.io server

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ab967de9083229545a678088c56df