### PR TITLE
Fix socket.io client references

### DIFF
--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,4 +1,6 @@
 
+import { io } from 'socket.io-client';
+
 let socket;
 
 export default function ChatBox({ sessionId }) {

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -4,6 +4,7 @@ import MonstersList from "../components/MonstersList";
 import ChatComponent from "../components/ChatComponent";
 import PlayerCard from "../components/PlayerCard";
 import MusicPlayer from "../components/MusicPlayer";
+import { io } from 'socket.io-client';
 
 // socket connection URL configurable via env
 const socket = io(import.meta.env.VITE_SOCKET_URL);

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,3 +1,5 @@
+import { io } from 'socket.io-client';
+
 const socket = io(import.meta.env.VITE_SOCKET_URL);
 
 export default function LobbyPage({ tableId, user }) {


### PR DESCRIPTION
## Summary
- import `io` from `socket.io-client` in frontend modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac7910854832286557b41152669ca