### PR TITLE
Connect ToastContext to Axios

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,23 +1,34 @@
 import axios from "axios";
 
+// Holds ToastContext's showToast function. Call setAxiosToast(showToast) from a
+// React component to enable toast notifications for API errors.
+let showToast;
+
+export function setAxiosToast(fn) {
+  showToast = fn;
+}
+
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_URL || "http://localhost:5000",
   withCredentials: true,
 });
 
-// Optional interceptor to use with ToastContext (for custom integration)
+// Response interceptor uses ToastContext. Call setAxiosToast from a component
+// with the showToast function to display API errors globally.
 instance.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response) {
-      const status = error.response.status;
-      if (status === 401) {
-        toast.error("Авторизація потрібна");
-      } else if (status >= 500) {
-        toast.error("Серверна помилка");
+    if (showToast) {
+      if (error.response) {
+        const status = error.response.status;
+        if (status === 401) {
+          showToast("Авторизація потрібна", "error");
+        } else if (status >= 500) {
+          showToast("Серверна помилка", "error");
+        }
+      } else {
+        showToast("Мережева помилка", "error");
       }
-    } else {
-      toast.error("Мережева помилка");
     }
     return Promise.reject(error);
   }

--- a/frontend/src/components/AxiosToastProvider.jsx
+++ b/frontend/src/components/AxiosToastProvider.jsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useToast } from "../context/ToastContext";
+import { setAxiosToast } from "../api/axios";
+
+export default function AxiosToastProvider() {
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    setAxiosToast(showToast);
+  }, [showToast]);
+
+  return null;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,12 +6,14 @@ import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import { SettingsProvider } from './context/SettingsContext';
 import { ToastProvider } from './context/ToastContext';
+import AxiosToastProvider from './components/AxiosToastProvider';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <SettingsProvider>
         <ToastProvider>
+          <AxiosToastProvider />
           <App />
         </ToastProvider>
       </SettingsProvider>


### PR DESCRIPTION
## Summary
- allow axios interceptor to display toasts
- bridge ToastContext to axios with a new component
- initialize the bridge in `main.jsx`

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684adf3c9844832286dd32d0383b4755