### PR TITLE
Fix missing imports for user store

### DIFF
--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -1,4 +1,5 @@
-
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export const useUserStore = create(
   persist(


### PR DESCRIPTION
## Summary
- ensure the zustand store imports `create` and `persist`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aec2710b88322aa2c7dacc08e2f32