### PR TITLE
Add missing imports for toast and navigation

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,10 @@
 
 
+import { Link, useNavigate } from 'react-router-dom';
+import { useToast } from '../context/ToastContext';
+import { useSettings } from '../context/SettingsContext';
+import { useTranslation } from 'react-i18next';
+import { useUserStore } from '../store/user';
 import { useState } from 'react';
 import api from "../api/axios";
 

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,6 +1,9 @@
 
 import axios from "axios";
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '../context/ToastContext';
+import { useTranslation } from 'react-i18next';
 
 function RegisterPage() {
   const [login, setLogin] = useState("");


### PR DESCRIPTION
## Summary
- add toast/navigate/store imports in `LoginPage`
- add toast/navigate imports in `RegisterPage`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684af1c9f5d48322925983848e438986