### PR TITLE
Add Navigate import to PrivateRoute

### DIFF
--- a/frontend/src/PrivateRoute.jsx
+++ b/frontend/src/PrivateRoute.jsx
@@ -1,3 +1,4 @@
+import { Navigate } from 'react-router-dom';
 
 function PrivateRoute({ children }) {
   const token = localStorage.getItem("token");


### PR DESCRIPTION
## Summary
- add missing Navigate import for React routing

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684af1c92bc4832290b037bae5ce297d