### PR TITLE
Fix missing page imports

### DIFF
--- a/frontend/src/pages/AdminStats.jsx
+++ b/frontend/src/pages/AdminStats.jsx
@@ -1,4 +1,6 @@
 
+import { Bar } from 'react-chartjs-2'
+
 export default function AdminStats({ data }) {
   const races = data.map(d => d.race);
   const counts = data.map(d => d.count);

--- a/frontend/src/pages/ChangePasswordPage.jsx
+++ b/frontend/src/pages/ChangePasswordPage.jsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom'
 import Navbar from "../components/Navbar";
 
 function ChangePasswordPage() {

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,5 +1,6 @@
 import api from "../api/axios";
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom'
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();

--- a/frontend/src/pages/CharacterEditPage.jsx
+++ b/frontend/src/pages/CharacterEditPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api/axios";
 import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom'
 
 export default function CharacterEditPage() {
   const { id } = useParams();

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from "../api/axios";
+import { useNavigate } from 'react-router-dom'
 
 export default function CharacterListPage() {
   const [characters, setCharacters] = useState([]);

--- a/frontend/src/pages/CharactersPage.jsx
+++ b/frontend/src/pages/CharactersPage.jsx
@@ -1,4 +1,6 @@
 
+import { useUserStore } from '../store/user'
+
 export default function CharactersPage() {
   const { user } = useUserStore();
 

--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -1,5 +1,7 @@
 
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom'
+import { createCharacter } from '../utils/api'
 
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -6,6 +6,8 @@ import PlayerCard from "../components/PlayerCard";
 import MusicPlayer from "../components/MusicPlayer";
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
+import { useParams } from 'react-router-dom'
+import { useUserStore } from '../store/user'
 
 // socket connection URL configurable via env
 const socket = io(import.meta.env.VITE_SOCKET_URL);

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
+import { useNavigate } from 'react-router-dom'
 
 const socket = io(import.meta.env.VITE_SOCKET_URL);
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -2,6 +2,11 @@
 
 import { useState } from 'react';
 import api from "../api/axios";
+import { Link, useNavigate } from 'react-router-dom'
+import { useToast } from '../context/ToastContext'
+import { useSettings } from '../context/SettingsContext'
+import { useTranslation } from 'react-i18next'
+import { useUserStore } from '../store/user'
 
 function LoginPage() {
   const [login, setLogin] = useState("");

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -1,4 +1,6 @@
 
+import { useUserStore } from '../store/user'
+
 export default function MainPage() {
   const { user } = useUserStore();
 

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,4 +1,6 @@
 
+import { Link } from 'react-router-dom'
+
 export default function NotFoundPage() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-black text-white font-dnd">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,5 +1,7 @@
 
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom'
+import { getCharacters, deleteCharacter } from '../utils/api'
 
 const ProfilePage = () => {
   const [characters, setCharacters] = useState([]);

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,6 +1,9 @@
 
 import axios from "axios";
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom'
+import { useToast } from '../context/ToastContext'
+import { useTranslation } from 'react-i18next'
 
 function RegisterPage() {
   const [login, setLogin] = useState("");

--- a/frontend/src/pages/SettingsPanel.jsx
+++ b/frontend/src/pages/SettingsPanel.jsx
@@ -1,4 +1,6 @@
 
+import { useSettings } from '../context/SettingsContext'
+
 export default function SettingsPanel() {
   const { brightness, setBrightness, volume, setVolume, language, setLanguage } = useSettings();
 

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom'
+import { useUserStore } from '../../store/user'
 
 export default function AdminCharacteristicsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom'
+import { useUserStore } from '../../store/user'
 
 export default function AdminMapsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom'
+import { useUserStore } from '../../store/user'
 
 export default function AdminMusicPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom'
+import { useUserStore } from '../../store/user'
 
 export default function AdminProfessionsPage() {
   const { token } = useUserStore();

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom'
+import { useUserStore } from '../../store/user'
 
 export default function AdminRacesPage() {
   const { token } = useUserStore();


### PR DESCRIPTION
## Summary
- add missing hooks in pages for router, user store and settings
- include Link imports for pages with navigation links
- export Bar chart import in AdminStats

## Testing
- `npm --version`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af1c9ef7883228645dae365909aae