### PR TITLE
Fix stray text in RegisterPage

### DIFF
--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,12 +1,9 @@
-
 import axios from "axios";
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom'
 import { useToast } from '../context/ToastContext'
 import { useTranslation } from 'react-i18next'
- main
-
 function RegisterPage() {
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");


### PR DESCRIPTION
## Summary
- remove stray `main` line from RegisterPage
- ensure imports flow directly into the RegisterPage definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af5e0eafc8322bde8ac3c7a74bf2b