### PR TITLE
Fix missing global imports for frontend

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,9 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { SettingsProvider } from './context/SettingsContext';
 import { ToastProvider } from './context/ToastContext';
+import './i18n';
+import './index.css';
+import './App.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- load i18n configuration before rendering
- import global stylesheets in `main.jsx`

## Testing
- `npm install`
- `npm run build`
- `npm run dev` *(fails: Stopped after start to show output)*

------
https://chatgpt.com/codex/tasks/task_e_684afa02f6448322bf521770e428c376