### PR TITLE
Update Axios baseURL and paths

### DIFF
--- a/frontend/src/api/adminActions.js
+++ b/frontend/src/api/adminActions.js
@@ -1,17 +1,17 @@
 import api from "./axios";
 
 // СЕСІЇ
-export const startSession = () => api.post("/api/session/start");
-export const endSession = () => api.post("/api/session/end");
-export const getSessionLog = () => api.get("/api/session/log");
+export const startSession = () => api.post("/session/start");
+export const endSession = () => api.post("/session/end");
+export const getSessionLog = () => api.get("/session/log");
 
 // Музика
-export const setMusic = (url) => api.post("/api/music", { url });
+export const setMusic = (url) => api.post("/music", { url });
 
 // Раси
-export const createRace = (data) => api.post("/api/races", data);
-export const getRaces = () => api.get("/api/races");
-export const deleteRace = (id) => api.delete(`/api/races/${id}`);
+export const createRace = (data) => api.post("/races", data);
+export const getRaces = () => api.get("/races");
+export const deleteRace = (id) => api.delete(`/races/${id}`);
 
 // Карти
-export const uploadMap = (data) => api.post("/api/maps", data);
+export const uploadMap = (data) => api.post("/maps", data);

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -9,7 +9,7 @@ export function setAxiosToast(fn) {
 }
 
 const instance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || "http://localhost:5000",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:5000/api",
   withCredentials: true,
 });
 

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -15,7 +15,7 @@ export default function MusicPlayer({ isGM }) {
 
   const fetchTracks = async () => {
     try {
-      const res = await api.get('/api/music');
+      const res = await api.get('/music');
       setTracks(res.data);
     } catch (e) {
       console.error(e);
@@ -30,7 +30,7 @@ export default function MusicPlayer({ isGM }) {
     e.preventDefault();
     if (!title || !url) return;
     try {
-      await api.post('/api/music', { title, url });
+      await api.post('/music', { title, url });
       setTitle('');
       setUrl('');
       fetchTracks();
@@ -41,7 +41,7 @@ export default function MusicPlayer({ isGM }) {
 
   const removeTrack = async (id) => {
     try {
-      await api.delete(`/api/music/${id}`);
+      await api.delete(`/music/${id}`);
       if (current && current._id === id) setCurrent(null);
       fetchTracks();
     } catch (e) {

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -7,7 +7,7 @@ export default function AdminPanel() {
 
   useEffect(() => {
     axios
-      .get("/api/stats/races")
+      .get("/stats/races")
       .then((res) => setRaceStats(res.data))
       .catch(() => setRaceStats([]));
   }, []);

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -18,7 +18,7 @@ export default function CharacterCreatePage() {
         return;
       }
 
-      await api.post("/api/character", form);
+      await api.post("/character", form);
       navigate("/profile");
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/CharacterEditPage.jsx
+++ b/frontend/src/pages/CharacterEditPage.jsx
@@ -12,7 +12,7 @@ export default function CharacterEditPage() {
 
   useEffect(() => {
 
-    api.get(`/api/character/${id}`)
+    api.get(`/character/${id}`)
       .then(res => {
         setCharacter(res.data);
         setName(res.data.name || "");
@@ -26,7 +26,7 @@ export default function CharacterEditPage() {
     setError("");
     try {
 
-      await api.put(`/api/character/${id}`, { name, description });
+      await api.put(`/character/${id}`, { name, description });
       navigate("/characters");
     } catch (err) {
       setError("Не вдалося зберегти зміни");

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -7,7 +7,7 @@ export default function CharacterListPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    api.get("/api/character").then(res => setCharacters(res.data));
+    api.get("/character").then(res => setCharacters(res.data));
   }, []);
 
   return (

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/user'
@@ -12,7 +12,7 @@ export default function AdminCharacteristicsPage() {
 
   const fetchCharacteristics = async () => {
     setLoading(true);
-    const res = await axios.get('/api/characteristic', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/characteristic', { headers: { Authorization: `Bearer ${token}` } });
     setCharacteristics(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminCharacteristicsPage() {
 
   const addCharacteristic = async (e) => {
     e.preventDefault();
-    await axios.post('/api/characteristic', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/characteristic', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchCharacteristics();
   };
 
   const removeCharacteristic = async (id) => {
-    await axios.delete(`/api/characteristic/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/characteristic/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchCharacteristics();
   };
 

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../api/axios';
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/user'
@@ -13,7 +13,7 @@ export default function AdminMapsPage() {
 
   const fetchMaps = async () => {
     setLoading(true);
-    const res = await axios.get('/api/map', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/map', { headers: { Authorization: `Bearer ${token}` } });
     setMaps(res.data);
     setLoading(false);
   };
@@ -25,14 +25,14 @@ export default function AdminMapsPage() {
     const formData = new FormData();
     formData.append('name', name);
     formData.append('image', file);
-    await axios.post('/api/map', formData, {
+    await api.post('/map', formData, {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' },
     });
     setName(''); setFile(null); fileInput.current.value = null; fetchMaps();
   };
 
   const removeMap = async (id) => {
-    await axios.delete(`/api/map/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/map/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchMaps();
   };
 

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/user'
@@ -12,7 +12,7 @@ export default function AdminMusicPage() {
 
   const fetchTracks = async () => {
     setLoading(true);
-    const res = await axios.get('/api/music', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/music', { headers: { Authorization: `Bearer ${token}` } });
     setTracks(res.data);
     setLoading(false);
   };
@@ -21,12 +21,12 @@ export default function AdminMusicPage() {
   const addTrack = async (e) => {
     e.preventDefault();
     if (!title || !url) return;
-    await axios.post('/api/music', { title, url }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/music', { title, url }, { headers: { Authorization: `Bearer ${token}` } });
     setTitle(''); setUrl(''); fetchTracks();
   };
 
   const removeTrack = async (id) => {
-    await axios.delete(`/api/music/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/music/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchTracks();
   };
 

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/user'
@@ -12,7 +12,7 @@ export default function AdminProfessionsPage() {
 
   const fetchProfessions = async () => {
     setLoading(true);
-    const res = await axios.get('/api/profession', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/profession', { headers: { Authorization: `Bearer ${token}` } });
     setProfessions(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminProfessionsPage() {
 
   const addProfession = async (e) => {
     e.preventDefault();
-    await axios.post('/api/profession', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/profession', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchProfessions();
   };
 
   const removeProfession = async (id) => {
-    await axios.delete(`/api/profession/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/profession/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchProfessions();
   };
 

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/user'
@@ -12,7 +12,7 @@ export default function AdminRacesPage() {
 
   const fetchRaces = async () => {
     setLoading(true);
-    const res = await axios.get('/api/race', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/race', { headers: { Authorization: `Bearer ${token}` } });
     setRaces(res.data);
     setLoading(false);
   };
@@ -20,12 +20,12 @@ export default function AdminRacesPage() {
 
   const addRace = async (e) => {
     e.preventDefault();
-    await axios.post('/api/race', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/race', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
     setName(''); setDescription(''); fetchRaces();
   };
 
   const removeRace = async (id) => {
-    await axios.delete(`/api/race/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/race/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     fetchRaces();
   };
 


### PR DESCRIPTION
## Summary
- set axios default baseURL to include `/api`
- drop `/api` prefix from Axios-based calls
- adjust admin pages to use shared Axios instance

## Testing
- `npm --prefix backend test --silent`
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684afa0459888322a2880ea7917cb656