### PR TITLE
Fix missing react-router imports

### DIFF
--- a/frontend/src/components/LogoutButton.jsx
+++ b/frontend/src/components/LogoutButton.jsx
@@ -1,4 +1,4 @@
-
+import { useNavigate } from 'react-router-dom';
 function LogoutButton() {
   const navigate = useNavigate();
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import LanguageSwitch from './LanguageSwitch';
 
 function Navbar() {


### PR DESCRIPTION
## Summary
- import `Link` and `useNavigate` in `Navbar.jsx`
- import `useNavigate` in `LogoutButton.jsx`

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684b018aa79083229cf55eb95f6642b3