### PR TITLE
Add DnD palette colors and shadow style

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,9 +8,14 @@ module.exports = {
     extend: {
       colors: {
         dndgold: '#FFD700',
+        dndred: '#8B0000',
+        dndbg: '#322018',
       },
       fontFamily: {
         dnd: ['"IM Fell English SC"', 'serif'],
+      },
+      boxShadow: {
+        dnd: '0 0 10px rgba(0, 0, 0, 0.7), 0 0 0 2px #FFD700',
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend theme colors and shadows in `frontend/tailwind.config.js`

## Testing
- `npm test` in `backend`
- `npm install` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684b0189c3e4832291b26c3c11eddd96