### PR TITLE
Rename bio to description in character pages

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: "", bio: "" });
+  const [form, setForm] = useState({ name: "", description: "" });
   const [error, setError] = useState(null);
 
   const handleChange = (e) => {
@@ -13,12 +13,13 @@ export default function CharacterCreatePage() {
 
   const handleSubmit = async () => {
     try {
-      if (!form.name || !form.bio) {
+      if (!form.name || !form.description) {
         setError("Будь ласка, заповніть всі поля.");
         return;
       }
 
-      await api.post("/character", form);
+      const payload = { name: form.name, description: form.description };
+      await api.post("/character", payload);
       navigate("/profile");
     } catch (err) {
       console.error(err);
@@ -37,10 +38,10 @@ export default function CharacterCreatePage() {
           onChange={handleChange}
           className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
         />
-        <label className="block text-sm mb-1">Біо</label>
+        <label className="block text-sm mb-1">Опис</label>
         <textarea
-          name="bio"
-          value={form.bio}
+          name="description"
+          value={form.description}
           onChange={handleChange}
           className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
         />

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -17,7 +17,7 @@ export default function CharacterListPage() {
         {characters.map(c => (
           <div key={c._id} className="bg-[#1c120a]/80 p-4 rounded-xl shadow-lg border border-dndgold">
             <h2 className="text-xl text-dndgold">{c.name}</h2>
-            <p className="text-sm italic mb-2">{c.bio}</p>
+            <p className="text-sm italic mb-2">{c.description}</p>
             <p className="text-xs">Раса: {c.race?.name || "—"}</p>
             <p className="text-xs">Клас: {c.profession?.name || "—"}</p>
             <button


### PR DESCRIPTION
## Summary
- update character create form field from `bio` to `description`
- adjust submission payload for new field
- show `description` instead of `bio` in list page

## Testing
- `npm install` & `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_684b0b093a608322a587e3de44ed1528