### PR TITLE
Apply map background to profile page

### DIFF
--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -19,7 +19,10 @@ const ProfilePage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-dndbg flex flex-col items-center p-6 font-dnd text-dndgold">
+    <div
+      className="min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold"
+      style={{ backgroundImage: "url('/map-bg.jpg')" }}
+    >
       <h2 className="text-2xl mb-4">Твої персонажі</h2>
       <button
         onClick={handleCreate}


### PR DESCRIPTION
## Summary
- adjust `ProfilePage` layout to use the map background like other pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b11fb45688322a1e21fa841d7ad24