### PR TITLE
Add MongoDB seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ This project combines an Express/MongoDB backend with a React frontend.
    - `VITE_API_URL` – base URL of the backend API (e.g. `http://localhost:5000/api`)
    - `VITE_SOCKET_URL` – URL of the Socket.io server (e.g. `http://localhost:5000`)
 
+3. **Seed starter data** (optional)
+
+   Populate the database with some basic races, professions and
+   characteristics:
+
+   ```bash
+   cd backend
+   node scripts/seed.js
+   ```
+
 ## Running the app
 
 ### Backend

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -1,0 +1,43 @@
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+const mongoose = require('mongoose');
+
+const Race = require('../src/models/Race');
+const Profession = require('../src/models/Profession');
+const Characteristic = require('../src/models/Characteristic');
+
+const MONGO_URI = process.env.MONGO_URI;
+
+if (!MONGO_URI) {
+  console.error('MONGO_URI is not defined in environment');
+  process.exit(1);
+}
+
+async function seed() {
+  await mongoose.connect(MONGO_URI);
+
+  const races = ['Human', 'Elf', 'Dwarf'];
+  const professions = ['Warrior', 'Mage', 'Rogue'];
+  const characteristics = ['Strength', 'Agility', 'Intelligence'];
+
+  if (await Race.countDocuments() === 0) {
+    await Race.insertMany(races.map(name => ({ name })));
+    console.log('Races seeded');
+  }
+
+  if (await Profession.countDocuments() === 0) {
+    await Profession.insertMany(professions.map(name => ({ name })));
+    console.log('Professions seeded');
+  }
+
+  if (await Characteristic.countDocuments() === 0) {
+    await Characteristic.insertMany(characteristics.map(name => ({ name })));
+    console.log('Characteristics seeded');
+  }
+
+  await mongoose.disconnect();
+}
+
+seed().catch(err => {
+  console.error(err);
+  mongoose.disconnect();
+});


### PR DESCRIPTION
## Summary
- provide `backend/scripts/seed.js` to populate starter data
- document how to run the seeding script in the README

## Testing
- `npm install` (backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b11f99bb483229c9c6a3e581f3c28