### PR TITLE
Improve lobby table initialization

### DIFF
--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,28 +1,49 @@
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useUserStore } from '../store/user';
 
 const socket = io(import.meta.env.VITE_SOCKET_URL);
 
-export default function LobbyPage({ tableId, user }) {
+export default function LobbyPage() {
+  const [searchParams] = useSearchParams();
+  const { user } = useUserStore();
+  const [tableId, setTableId] = useState(null);
   const [players, setPlayers] = useState([]);
   const [isGM, setIsGM] = useState(false);
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
-  useEffect(() => {
-    socket.emit("join-lobby", { tableId, user });
-    socket.on("lobby-players", data => setPlayers(data.players));
-    socket.on("gm-assigned", () => setIsGM(true));
-    socket.on("game-started", () => navigate(`/table/${tableId}`));
-    return () => socket.disconnect();
-  }, [tableId, user, navigate]);
+  const char = searchParams.get('char');
 
-  const startGame = () => socket.emit("start-game", { tableId });
+  // generate tableId on mount
+  useEffect(() => {
+    const id = Math.random().toString(36).substring(2, 8);
+    setTableId(id);
+  }, []);
+
+  useEffect(() => {
+    if (!tableId || !user) {
+      if (!tableId) setError('Не вдалося отримати код столу');
+      return;
+    }
+    setError('');
+    socket.emit('join-lobby', { tableId, user, char });
+    socket.on('lobby-players', data => setPlayers(data.players));
+    socket.on('gm-assigned', () => setIsGM(true));
+    socket.on('game-started', () => navigate(`/table/${tableId}`));
+    return () => socket.disconnect();
+  }, [tableId, user, char, navigate]);
+
+  const startGame = () => {
+    if (tableId) socket.emit('start-game', { tableId });
+  };
 
   return (
     <div className="flex flex-col items-center min-h-screen bg-dndbg">
       <div className="bg-[#322018]/90 p-6 rounded-2xl mt-10 w-full max-w-lg">
         <h1 className="text-3xl font-dnd text-dndgold text-center mb-2">Лобі столу</h1>
+        {error && <div className="text-red-500 mb-2">{error}</div>}
         <div className="text-dndgold mb-2">Код для підключення: <b>{tableId}</b></div>
         <div className="text-dndgold mb-4">Гравці:</div>
         <ul>


### PR DESCRIPTION
## Summary
- create the table id inside `LobbyPage` and keep it in state
- retrieve the current user via `useUserStore`
- read the `char` query string param
- connect to the socket with the resolved user/table id
- display an error when table id generation fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b37d3351c8322abb6ba23af6f41e0