### PR TITLE
Fix dice roll ternary expression

### DIFF
--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -46,7 +46,7 @@ export default function GameTablePage() {
     setDiceAnim(true);
     setTimeout(() => {
       setDiceAnim(false);
-      const res = type === "d20";
+      const res = type === "d20"
         ? Math.ceil(Math.random() * 20)
         : Math.ceil(Math.random() * 6);
       setDiceResult(res);


### PR DESCRIPTION
## Summary
- fix ternary operator in GameTablePage so the dice roll returns correct values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b37d47540832281c4ec2d48eca69f