### PR TITLE
Remove duplicate PostCSS config

### DIFF
--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Summary
- remove unused `postcss.config.cjs`
- keep `postcss.config.js` for PostCSS configuration

## Testing
- `npm test` in `backend`
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684b37d6f7408322a46477a79fce4176