### PR TITLE
Handle empty race/prof arrays

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -42,17 +42,23 @@ exports.create = async (req, res) => {
     ];
 
     // Обрати рандомно расу, професію і базові стати з колекції
-    let race = await Race.aggregate([{ $sample: { size: 1 } }]);
-    if (!race.length) {
-      const fallback = await Race.find().limit(1);
-      race = fallback;
-    }
+  let race = await Race.aggregate([{ $sample: { size: 1 } }]);
+  if (!race.length) {
+    const fallback = await Race.find().limit(1);
+    race = fallback;
+  }
 
-    let profession = await Profession.aggregate([{ $sample: { size: 1 } }]);
-    if (!profession.length) {
-      const fallback = await Profession.find().limit(1);
-      profession = fallback;
-    }
+  let profession = await Profession.aggregate([{ $sample: { size: 1 } }]);
+  if (!profession.length) {
+    const fallback = await Profession.find().limit(1);
+    profession = fallback;
+  }
+
+  if (!race.length || !profession.length) {
+    return res.status(500).json({
+      message: 'Missing races or professions to create character'
+    });
+  }
 
     let characteristics = await Characteristic.find();
     if (!characteristics.length) {

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -35,4 +35,22 @@ describe('Character Controller - create', () => {
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalled();
   });
+
+  it('returns 500 if races or professions are missing', async () => {
+    Race.aggregate.mockResolvedValue([]);
+    Race.find.mockReturnValue({ limit: jest.fn().mockResolvedValue([]) });
+    Profession.aggregate.mockResolvedValue([]);
+    Profession.find.mockReturnValue({ limit: jest.fn().mockResolvedValue([]) });
+    Characteristic.find.mockResolvedValue([{ _id: 'c1', name: 'hp' }]);
+
+    const req = { user: { id: 'u1' }, body: { name: 'Hero', description: '', image: '' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Missing races or professions to create character'
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure creating a character fails when race or profession collections are empty
- test controller behavior for empty collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b37d99abc8322bf38cb1ee9dc6597