### PR TITLE
Update inventory pool across backend and frontend

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -3,7 +3,23 @@ const Race = require('../models/Race');
 const Profession = require('../models/Profession');
 const Characteristic = require('../models/Characteristic');
 
-const inventoryPool = ['Sword', 'Bow', 'Dagger', 'Staff', 'Shield', 'Potion'];
+const inventoryPool = [
+  'Sword',
+  'Bow',
+  'Dagger',
+  'Staff',
+  'Shield',
+  'Potion',
+  'Axe',
+  'Spear',
+  'Mace',
+  'Helmet',
+  'Armor',
+  'Lantern',
+  'Rope',
+  'Lockpick',
+  'Food Rations'
+];
 const hpRanges = {
   Warrior: { min: 16, max: 20 },
   Wizard: { min: 6, max: 10 },

--- a/frontend/src/utils/characterUtils.js
+++ b/frontend/src/utils/characterUtils.js
@@ -1,7 +1,23 @@
 export const races = ['Human', 'Elf', 'Dwarf', 'Orc'];
 export const classes = ['Warrior', 'Wizard', 'Rogue'];
 
-const inventoryPool = ['Sword', 'Bow', 'Dagger', 'Staff', 'Shield', 'Potion'];
+const inventoryPool = [
+  'Sword',
+  'Bow',
+  'Dagger',
+  'Staff',
+  'Shield',
+  'Potion',
+  'Axe',
+  'Spear',
+  'Mace',
+  'Helmet',
+  'Armor',
+  'Lantern',
+  'Rope',
+  'Lockpick',
+  'Food Rations'
+];
 
 export const getRandomElement = (arr) => arr[Math.floor(Math.random() * arr.length)];
 


### PR DESCRIPTION
## Summary
- expand inventory items available when creating characters
- mirror the new item list in the frontend utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3d1d03688322847ec462ddca4e71