### PR TITLE
Fix seeding script profession name

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -16,7 +16,7 @@ async function seed() {
   await mongoose.connect(MONGO_URI);
 
   const races = ['Human', 'Elf', 'Dwarf'];
-  const professions = ['Warrior', 'Mage', 'Rogue'];
+  const professions = ['Warrior', 'Wizard', 'Rogue'];
   const characteristics = ['Strength', 'Agility', 'Intelligence'];
 
   if (await Race.countDocuments() === 0) {


### PR DESCRIPTION
## Summary
- update the default professions in `seed.js` to use `Wizard` instead of `Mage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3d2195988322b2565c1c01ddab49