### PR TITLE
Fix status code for missing character data

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -71,7 +71,7 @@ exports.create = async (req, res) => {
   }
 
   if (!race.length || !profession.length) {
-    return res.status(500).json({
+    return res.status(400).json({
       message: 'Missing races or professions to create character'
     });
   }

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -48,7 +48,7 @@ describe('Character Controller - create', () => {
 
     await characterController.create(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({
       message: 'Missing races or professions to create character'
     });


### PR DESCRIPTION
## Summary
- return HTTP 400 when races or professions are absent in `characterController.create`
- adjust character controller test to expect 400 status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b418b9748832286956f098c331005