### PR TITLE
Fix language persistence

### DIFF
--- a/frontend/src/components/LanguageSwitch.jsx
+++ b/frontend/src/components/LanguageSwitch.jsx
@@ -1,8 +1,10 @@
 
+import i18n from '../i18n';
+
 export default function LanguageSwitch() {
   const changeLanguage = (lang) => {
-    localStorage.setItem("lang", lang);
-    window.location.reload();
+    localStorage.setItem('lang', lang);
+    i18n.changeLanguage(lang);
   };
 
   return (

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -3,6 +3,8 @@ import { initReactI18next } from 'react-i18next';
 import en from './locales/en.json';
 import ua from './locales/ua.json';
 
+const storedLang = localStorage.getItem('lang') || 'ua';
+
 i18n
   .use(initReactI18next)
   .init({
@@ -10,8 +12,8 @@ i18n
       en: { translation: en },
       ua: { translation: ua },
     },
-    lng: 'ua',
-    fallbackLng: 'ua',
+    lng: storedLang,
+    fallbackLng: storedLang,
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
## Summary
- initialize i18n language from `localStorage`
- switch language with `i18n.changeLanguage` instead of reloading

## Testing
- `npm test` in `backend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b623382f0832282402213a152de9b