### PR TITLE
Add navigation controls to create and lobby pages

### DIFF
--- a/frontend/src/components/LogoutButton.jsx
+++ b/frontend/src/components/LogoutButton.jsx
@@ -1,16 +1,19 @@
 import { useNavigate } from 'react-router-dom';
+import { useUserStore } from '../store/user';
+
 function LogoutButton() {
   const navigate = useNavigate();
+  const logout = useUserStore((s) => s.logout);
 
   const handleLogout = () => {
-    localStorage.removeItem("token");
-    navigate("/login");
+    logout();
+    navigate('/login');
   };
 
   return (
     <button
       onClick={handleLogout}
-      className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded"
+      className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition"
     >
       Вийти
     </button>

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,6 +1,7 @@
 import api from "../api/axios";
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom'
+import LogoutButton from "../components/LogoutButton";
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
@@ -28,7 +29,16 @@ export default function CharacterCreatePage() {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen font-dnd text-white bg-cover bg-center" style={{ backgroundImage: "url('/map-bg.jpg')" }}>
+    <div className="relative flex justify-center items-center min-h-screen font-dnd text-white bg-cover bg-center" style={{ backgroundImage: "url('/map-bg.jpg')" }}>
+      <div className="absolute top-4 right-4 flex gap-2">
+        <button
+          onClick={() => navigate('/profile')}
+          className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-4 py-2 transition"
+        >
+          Назад
+        </button>
+        <LogoutButton />
+      </div>
       <div className="bg-[#1c120a]/80 p-8 rounded-xl w-full max-w-md shadow-2xl">
         <h2 className="text-2xl text-dndgold mb-6 text-center">Створення персонажа</h2>
         <label className="block text-sm mb-1">Ім’я</label>

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useUserStore } from '../store/user';
+import LogoutButton from '../components/LogoutButton';
 
 const socket = io(import.meta.env.VITE_SOCKET_URL);
 
@@ -41,9 +42,18 @@ export default function LobbyPage() {
 
   return (
     <div
-      className="flex flex-col items-center min-h-screen bg-dndbg bg-cover bg-center"
+      className="relative flex flex-col items-center min-h-screen bg-dndbg bg-cover bg-center"
       style={{ backgroundImage: "url('/nd-bg.png')" }}
     >
+      <div className="absolute top-4 right-4 flex gap-2">
+        <button
+          onClick={() => navigate('/profile')}
+          className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-4 py-2 transition"
+        >
+          Назад
+        </button>
+        <LogoutButton />
+      </div>
       <div className="bg-[#322018]/90 p-6 rounded-2xl mt-10 w-full max-w-lg">
         <h1 className="text-3xl font-dnd text-dndgold text-center mb-2">Лобі столу</h1>
         {error && <div className="text-red-500 mb-2">{error}</div>}


### PR DESCRIPTION
## Summary
- add logout support via store in `LogoutButton`
- add `Назад` button and logout controls to character creation page
- add `Назад` button and logout controls to lobby page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b623519b88322a9ca0068a83d4c8f