### PR TITLE
Add logout controls to ProfilePage

### DIFF
--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,7 +1,8 @@
 
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom'
-import { getCharacters, deleteCharacter } from '../utils/api'
+import { useNavigate } from 'react-router-dom';
+import LogoutButton from '../components/LogoutButton';
+import { getCharacters, deleteCharacter } from '../utils/api';
 
 const ProfilePage = () => {
   const [characters, setCharacters] = useState([]);
@@ -20,9 +21,18 @@ const ProfilePage = () => {
 
   return (
     <div
-      className="min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold"
+      className="relative min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold"
       style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
+      <div className="absolute top-4 right-4 flex gap-2">
+        <button
+          onClick={() => navigate('/login')}
+          className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-4 py-2 transition"
+        >
+          Назад
+        </button>
+        <LogoutButton />
+      </div>
       <h2 className="text-2xl mb-4">Твої персонажі</h2>
       <button
         onClick={handleCreate}


### PR DESCRIPTION
## Summary
- import `LogoutButton` into `ProfilePage`
- add absolute header with back and logout buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b66095a088322b7b050fb91a22481