### PR TITLE
Add stat generation utility

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -2,6 +2,7 @@ const Character = require('../models/Character');
 const Race = require('../models/Race');
 const Profession = require('../models/Profession');
 const Characteristic = require('../models/Characteristic');
+const generateStats = require('../utils/generateStats');
 
 const inventoryPool = [
   'Sword',
@@ -20,11 +21,6 @@ const inventoryPool = [
   'Lockpick',
   'Food Rations'
 ];
-const hpRanges = {
-  Warrior: { min: 16, max: 20 },
-  Wizard: { min: 6, max: 10 },
-  Rogue: { min: 10, max: 14 },
-};
 
 const getRandomInventory = () => {
   const count = Math.floor(Math.random() * 3) + 2; // 2-4 items
@@ -83,16 +79,9 @@ exports.create = async (req, res) => {
     }
 
     const profName = profession[0]?.name;
-    const hpChar = characteristics.find(c => c.name.toLowerCase() === 'hp');
-    const hpRange = hpRanges[profName] || { min: 3, max: 18 };
+    const raceName = race[0]?.name;
 
-    const stats = characteristics.map(char => {
-      let value = Math.floor(Math.random() * 16) + 3; // 3-18
-      if (hpChar && String(char._id) === String(hpChar._id)) {
-        value = Math.floor(Math.random() * (hpRange.max - hpRange.min + 1)) + hpRange.min;
-      }
-      return { characteristic: char._id, value };
-    });
+    const stats = generateStats(characteristics, raceName, profName);
 
     // Логіка вибору аватара
     const avatar = (image && image.trim())

--- a/backend/src/utils/generateStats.js
+++ b/backend/src/utils/generateStats.js
@@ -1,0 +1,58 @@
+const raceBonuses = {
+  Elf: { agility: 2, intellect: 1 },
+  Dwarf: { strength: 2 },
+  Human: { strength: 1, agility: 1, intellect: 1 }
+};
+
+const classMinimums = {
+  Warrior: { strength: 13, hp: 15 },
+  Wizard: { intellect: 12 },
+  Rogue: { agility: 12 }
+};
+
+/**
+ * Generate stats array based on available characteristics, race and class.
+ * @param {Array} characteristics - list of characteristic docs with _id and name
+ * @param {string} raceName - name of the race
+ * @param {string} className - name of the profession/class
+ * @returns {Array<{characteristic: string, value: number}>}
+ */
+function generateStats(characteristics, raceName, className) {
+  const stats = {};
+  // 1. start all at 10
+  characteristics.forEach(c => {
+    stats[c._id] = 10;
+  });
+
+  // 2. apply race bonuses
+  const raceMods = raceBonuses[raceName] || {};
+  Object.entries(raceMods).forEach(([name, bonus]) => {
+    const char = characteristics.find(c => c.name.toLowerCase() === name.toLowerCase());
+    if (char) {
+      stats[char._id] += bonus;
+    }
+  });
+
+  // 3. enforce class minimums
+  const classMins = classMinimums[className] || {};
+  Object.entries(classMins).forEach(([name, min]) => {
+    const char = characteristics.find(c => c.name.toLowerCase() === name.toLowerCase());
+    if (char) {
+      if (stats[char._id] < min) stats[char._id] = min;
+    }
+  });
+
+  // 4. randomize remaining values to 8-15
+  characteristics.forEach(c => {
+    const name = c.name.toLowerCase();
+    const hasBonus = raceMods[name] !== undefined;
+    const hasMin = classMins[name] !== undefined;
+    if (!hasBonus && !hasMin) {
+      stats[c._id] = Math.floor(Math.random() * (15 - 8 + 1)) + 8;
+    }
+  });
+
+  return Object.entries(stats).map(([id, value]) => ({ characteristic: id, value }));
+}
+
+module.exports = generateStats;

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -10,7 +10,7 @@ jest.mock('../src/models/Characteristic');
 jest.mock('../src/models/Character');
 
 describe('Character Controller - create', () => {
-  it('populates inventory and validates wizard hp range', async () => {
+  it('populates inventory and generates stats', async () => {
     Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
     Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard' }]);
     Characteristic.find.mockResolvedValue([
@@ -29,9 +29,10 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(savedData.inventory.length).toBeGreaterThanOrEqual(2);
-    const hp = savedData.stats.find(s => s.characteristic === 'c1').value;
-    expect(hp).toBeGreaterThanOrEqual(6);
-    expect(hp).toBeLessThanOrEqual(10);
+    savedData.stats.forEach(s => {
+      expect(s.value).toBeGreaterThanOrEqual(8);
+      expect(s.value).toBeLessThanOrEqual(15);
+    });
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- implement `generateStats` utility for race/class bonuses
- use the new utility in `characterController.create`
- update tests to validate stat generation

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684b6862b1dc8322942802cf74717ba5