### PR TITLE
Update README with stats info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This project combines an Express/MongoDB backend with a React frontend.
 
 3. **Seed starter data** (optional)
 
-   Populate the database with approximately ten races and ten professions
-   along with five core characteristics:
+   After updating your `.env` file, populate the database with approximately
+   ten races and ten professions along with five core characteristics:
 
    ```bash
    cd backend
@@ -60,4 +60,58 @@ can run the tests with:
 ```bash
 cd backend
 npm test
+```
+
+## Character Basics
+
+The seed script inserts five core statistics and example races/classes for
+testing.
+
+### Core statistics
+
+- **HP** – hit points
+- **MP** – magic points
+- **Strength**
+- **Agility**
+- **Intellect**
+
+### Races
+
+The following races are included:
+
+- Human
+- Elf
+- Dwarf
+- Orc
+- Halfling
+- Gnome
+- Tiefling
+- Dragonborn
+- Half-Elf
+- Half-Orc
+
+These races are provided without additional bonuses.
+
+### Classes
+
+Three example classes come with basic HP ranges used when generating stats:
+
+- **Warrior** – 16‑20 HP minimum
+- **Wizard** – 6‑10 HP minimum
+- **Rogue** – 10‑14 HP minimum
+
+Other attributes are rolled between 3 and 18.
+
+### Example stat generation
+
+```js
+const roll = () => Math.floor(Math.random() * 16) + 3; // 3‑18
+
+const stats = {
+  hp: roll(),
+  mp: roll(),
+  strength: roll(),
+  agility: roll(),
+  intellect: roll()
+};
 ```


### PR DESCRIPTION
## Summary
- document seeding step requires `.env`
- add section detailing core stats, races, classes and sample stat rolls

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684b686608e8832291a4894f4cc76879