### PR TITLE
Implement starter inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,12 @@ When creating a character, the race bonuses are applied first. Any class minimum
 const stats = generateStats('Elf', 'Mage');
 // => { STR: 10, DEX: 12, INT: 13, CON: 10, CHA: 11 }
 ```
+
+### Starter Inventory
+
+Each class begins with a predefined set of equipment which can be supplemented by race-specific items. The `generateInventory` utility merges these sets when a character is created.
+
+```js
+const inventory = generateInventory('Orc', 'Warrior');
+// => ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я', 'Кістяний талісман']
+```

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -4,34 +4,7 @@ const Profession = require('../models/Profession');
 
 
 const generateStats = require('../utils/generateStats');
-
-const inventoryPool = [
-  'Sword',
-  'Bow',
-  'Dagger',
-  'Staff',
-  'Shield',
-  'Potion',
-  'Axe',
-  'Spear',
-  'Mace',
-  'Helmet',
-  'Armor',
-  'Lantern',
-  'Rope',
-  'Lockpick',
-  'Food Rations'
-];
-
-const getRandomInventory = () => {
-  const count = Math.floor(Math.random() * 3) + 2; // 2-4 items
-  const items = [];
-  for (let i = 0; i < count; i++) {
-    const name = inventoryPool[Math.floor(Math.random() * inventoryPool.length)];
-    items.push({ item: name, amount: 1 });
-  }
-  return items;
-};
+const generateInventory = require('../utils/generateInventory');
 
 // Отримати всіх персонажів користувача
 exports.getAllByUser = async (req, res) => {
@@ -84,7 +57,7 @@ exports.create = async (req, res) => {
       ? image
       : defaultAvatars[Math.floor(Math.random() * defaultAvatars.length)];
 
-    const inventory = getRandomInventory();
+    const inventory = generateInventory(race[0].name, profession[0].name);
 
     const newChar = new Character({
       user: req.user.id,

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,0 +1,30 @@
+const classInventory = {
+  Warrior: ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я'],
+  Mage: ['Магічний посох', 'Книга заклять', 'Мана-зілля'],
+  Rogue: ['Кинджал', 'Плащ тіні', 'Відмички'],
+  Healer: ['Жезл лікування', 'Зілля лікування', 'Травник'],
+  Ranger: ['Лук', 'Колчан стріл', 'Ніж для виживання'],
+  Bard: ['Лютня', 'Легкий меч', 'Пісенник'],
+  Paladin: ['Молот', 'Латна броня', 'Святий амулет'],
+};
+
+const raceInventory = {
+  Elf: ['Ельфійські стріли'],
+  Orc: ['Кістяний талісман'],
+  Human: ['Монета удачі'],
+  Gnome: ['Гвинтовий ключ'],
+  Dwarf: ['Похідна кружка'],
+  Halfling: ['Трубка та тютюн'],
+  Demon: ['Темний камінь'],
+  Beastkin: ['Кігтістий амулет'],
+  Angel: ['Пір’я з крила'],
+  Lizardman: ['Луска пращура'],
+};
+
+function generateInventory(race, charClass) {
+  const classItems = classInventory[charClass] || [];
+  const raceItems = raceInventory[race] || [];
+  return [...classItems, ...raceItems].map(name => ({ item: name, amount: 1 }));
+}
+
+module.exports = generateInventory;

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,0 +1,20 @@
+const generateInventory = require('../src/utils/generateInventory');
+
+describe('generateInventory', () => {
+  it('combines items from class and race', () => {
+    const items = generateInventory('Orc', 'Warrior');
+    const names = items.map(i => i.item);
+    expect(names).toEqual([
+      'Меч',
+      'Щит',
+      'Шкіряна броня',
+      'Зілля здоров’я',
+      'Кістяний талісман'
+    ]);
+  });
+
+  it('returns empty array for unknown inputs', () => {
+    const items = generateInventory('Unknown', 'Unknown');
+    expect(items).toEqual([]);
+  });
+});

--- a/frontend/src/utils/characterUtils.js
+++ b/frontend/src/utils/characterUtils.js
@@ -20,23 +20,29 @@ export const classes = [
   'Paladin'
 ];
 
-const inventoryPool = [
-  'Sword',
-  'Bow',
-  'Dagger',
-  'Staff',
-  'Shield',
-  'Potion',
-  'Axe',
-  'Spear',
-  'Mace',
-  'Helmet',
-  'Armor',
-  'Lantern',
-  'Rope',
-  'Lockpick',
-  'Food Rations'
-];
+const classInventory = {
+  Warrior: ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я'],
+  Mage: ['Магічний посох', 'Книга заклять', 'Мана-зілля'],
+  Rogue: ['Кинджал', 'Плащ тіні', 'Відмички'],
+  Healer: ['Жезл лікування', 'Зілля лікування', 'Травник'],
+  Ranger: ['Лук', 'Колчан стріл', 'Ніж для виживання'],
+  Bard: ['Лютня', 'Легкий меч', 'Пісенник'],
+  Paladin: ['Молот', 'Латна броня', 'Святий амулет'],
+};
+
+const raceInventory = {
+  Elf: ['Ельфійські стріли'],
+  Orc: ['Кістяний талісман'],
+  Human: ['Монета удачі'],
+  Gnome: ['Гвинтовий ключ'],
+  Dwarf: ['Похідна кружка'],
+  Halfling: ['Трубка та тютюн'],
+  Demon: ['Темний камінь'],
+  Beastkin: ['Кігтістий амулет'],
+  Angel: ['Пір’я з крила'],
+  Lizardman: ['Луска пращура'],
+};
+
 
 export const getRandomElement = (arr) => arr[Math.floor(Math.random() * arr.length)];
 
@@ -78,11 +84,8 @@ export const getRandomStats = (charClass) => {
   return stats;
 };
 
-export const getRandomInventory = () => {
-  const count = randRange(2, 4);
-  const items = [];
-  for (let i = 0; i < count; i++) {
-    items.push(getRandomElement(inventoryPool));
-  }
-  return items;
+export const generateInventory = (race, charClass) => {
+  const classItems = classInventory[charClass] || [];
+  const raceItems = raceInventory[race] || [];
+  return [...classItems, ...raceItems];
 };


### PR DESCRIPTION
## Summary
- implement class/race inventory generator and docs
- use `generateInventory` when creating a character
- expose a utility for the frontend
- add tests for `generateInventory`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b6f9b4ba883228e09c219204f8b3b