### PR TITLE
Add avatar upload feature

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -31,7 +31,9 @@ app.use(express.json());
 // Ensure uploads directories exist
 const uploadDir = path.join(__dirname, '..', 'uploads');
 const mapsDir = path.join(uploadDir, 'maps');
+const avatarsDir = path.join(uploadDir, 'avatars');
 fs.mkdirSync(mapsDir, { recursive: true });
+fs.mkdirSync(avatarsDir, { recursive: true });
 
 // Serve uploaded files
 app.use('/uploads', express.static(uploadDir));

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -21,6 +21,7 @@ exports.getAllByUser = async (req, res) => {
 exports.create = async (req, res) => {
   try {
     const { name, description, image } = req.body;
+    const uploaded = req.file ? `/uploads/avatars/${req.file.filename}` : null;
 
     // Дефолтні аватари
 
@@ -53,9 +54,10 @@ exports.create = async (req, res) => {
  
 
     // Логіка вибору аватара
-    const avatar = (image && image.trim())
-      ? image
-      : defaultAvatars[Math.floor(Math.random() * defaultAvatars.length)];
+    const avatar = uploaded ||
+      ((image && image.trim())
+        ? image
+        : defaultAvatars[Math.floor(Math.random() * defaultAvatars.length)]);
 
     const inventory = generateInventory(race[0].name, profession[0].name);
 
@@ -93,9 +95,15 @@ exports.getOne = async (req, res) => {
 exports.update = async (req, res) => {
   try {
     const { name, description, image } = req.body;
+    const updateData = { name, description };
+    if (req.file) {
+      updateData.image = `/uploads/avatars/${req.file.filename}`;
+    } else if (image) {
+      updateData.image = image;
+    }
     const char = await Character.findOneAndUpdate(
       { _id: req.params.id, user: req.user.id },
-      { $set: { name, description, image } },
+      { $set: updateData },
       { new: true }
     );
     if (!char) return res.status(404).json({ message: 'Not found' });

--- a/backend/src/routes/character.js
+++ b/backend/src/routes/character.js
@@ -2,11 +2,19 @@ const express = require('express');
 const router = express.Router();
 const characterController = require('../controllers/characterController');
 const auth = require('../middlewares/authMiddleware');
+const multer = require('multer');
+const path = require('path');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, 'uploads/avatars/'),
+  filename: (req, file, cb) => cb(null, Date.now() + path.extname(file.originalname))
+});
+const upload = multer({ storage });
 
 router.get('/', auth, characterController.getAllByUser);
-router.post('/', auth, characterController.create);
+router.post('/', auth, upload.single('image'), characterController.create);
 router.get('/:id', auth, characterController.getOne);
-router.put('/:id', auth, characterController.update);
+router.put('/:id', auth, upload.single('image'), characterController.update);
 router.delete('/:id', auth, characterController.remove);
 
 module.exports = router;

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -49,4 +49,27 @@ describe('Character Controller - create', () => {
       message: 'Missing races or professions to create character'
     });
   });
+
+  it('uses uploaded avatar when file provided', async () => {
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+
+    let saved;
+    Character.mockImplementation(data => {
+      saved = data;
+      return { save: jest.fn().mockResolvedValue(data) };
+    });
+
+    const req = {
+      user: { id: 'u1' },
+      body: { name: 'Hero', description: '' },
+      file: { filename: 'avatar.png' }
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(saved.image).toBe('/uploads/avatars/avatar.png');
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
 });

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -6,6 +6,7 @@ import LogoutButton from "../components/LogoutButton";
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
   const [form, setForm] = useState({ name: "", description: "" });
+  const [image, setImage] = useState(null);
   const [error, setError] = useState(null);
 
   const handleChange = (e) => {
@@ -19,8 +20,19 @@ export default function CharacterCreatePage() {
         return;
       }
 
-      const payload = { name: form.name, description: form.description };
-      await api.post("/character", payload);
+      let payload;
+      let headers;
+      if (image) {
+        payload = new FormData();
+        payload.append('name', form.name);
+        payload.append('description', form.description);
+        payload.append('image', image);
+        headers = { 'Content-Type': 'multipart/form-data' };
+      } else {
+        payload = { name: form.name, description: form.description };
+        headers = { 'Content-Type': 'application/json' };
+      }
+      await api.post("/character", payload, { headers });
       navigate("/profile");
     } catch (err) {
       console.error(err);
@@ -54,6 +66,12 @@ export default function CharacterCreatePage() {
           value={form.description}
           onChange={handleChange}
           className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={e => setImage(e.target.files[0])}
+          className="mb-4"
         />
         {error && <p className="text-red-500 mb-4">{error}</p>}
         <button

--- a/frontend/src/pages/CharacterEditPage.jsx
+++ b/frontend/src/pages/CharacterEditPage.jsx
@@ -8,6 +8,7 @@ export default function CharacterEditPage() {
   const [character, setCharacter] = useState(null);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [image, setImage] = useState(null);
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -26,7 +27,19 @@ export default function CharacterEditPage() {
     setError("");
     try {
 
-      await api.put(`/character/${id}`, { name, description });
+      let payload;
+      let headers;
+      if (image) {
+        payload = new FormData();
+        payload.append('name', name);
+        payload.append('description', description);
+        payload.append('image', image);
+        headers = { 'Content-Type': 'multipart/form-data' };
+      } else {
+        payload = { name, description };
+        headers = { 'Content-Type': 'application/json' };
+      }
+      await api.put(`/character/${id}`, payload, { headers });
       navigate("/characters");
     } catch (err) {
       setError("Не вдалося зберегти зміни");
@@ -49,6 +62,11 @@ export default function CharacterEditPage() {
         value={description}
         onChange={e => setDescription(e.target.value)}
         placeholder="Опис"
+      />
+      <input
+        type="file"
+        accept="image/*"
+        onChange={e => setImage(e.target.files[0])}
       />
       <button type="submit">Зберегти</button>
     </form>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,10 +2,8 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
 const getAuthHeaders = () => {
   const token = localStorage.getItem('token');
-  return {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${token}`,
-  };
+  const headers = { Authorization: `Bearer ${token}` };
+  return headers;
 };
 
 export const getCharacters = async () => {
@@ -16,10 +14,21 @@ export const getCharacters = async () => {
 };
 
 export const createCharacter = async (data) => {
+  const headers = getAuthHeaders();
+  let body;
+  if (data.image instanceof File) {
+    body = new FormData();
+    Object.keys(data).forEach(key => {
+      if (data[key] !== undefined) body.append(key, data[key]);
+    });
+  } else {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(data);
+  }
   const res = await fetch(`${API_URL}/character`, {
     method: 'POST',
-    headers: getAuthHeaders(),
-    body: JSON.stringify(data),
+    headers,
+    body,
   });
   return res.json();
 };


### PR DESCRIPTION
## Summary
- allow uploading avatars for characters via multer
- persist uploaded avatar paths
- support avatar directories in backend app
- send multipart form data from the frontend
- expose file inputs on create/edit character pages
- test avatar upload logic

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_684b744736148322b1770ddc6c9d4a69