### PR TITLE
Improve profile page readability

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,3 +10,9 @@ body {
 .font-dnd {
   font-family: 'IM Fell English SC', serif;
 }
+
+@layer utilities {
+  .text-shadow {
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+  }
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -33,7 +33,7 @@ const ProfilePage = () => {
 
   return (
     <div
-      className="relative min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold"
+      className="relative min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold text-shadow"
       style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
       <div className="absolute top-4 right-4 flex gap-2">
@@ -45,7 +45,7 @@ const ProfilePage = () => {
         </button>
         <LogoutButton />
       </div>
-      <h2 className="text-2xl mb-4">Твої персонажі</h2>
+      <h2 className="text-2xl mb-4 text-shadow">Твої персонажі</h2>
       <button
         onClick={handleCreate}
         className="bg-dndgold text-dndred rounded-2xl px-4 py-2 font-semibold mb-6"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -19,5 +19,14 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addUtilities }) {
+      const newUtilities = {
+        '.text-shadow': {
+          textShadow: '2px 2px 4px rgba(0, 0, 0, 0.8)',
+        },
+      };
+      addUtilities(newUtilities);
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- add a custom `text-shadow` utility via Tailwind plugin
- expose the utility through `@layer utilities`
- use the shadow on Profile page container and heading

## Testing
- `npm test` in `backend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684be80495c48322809fb460c0349648