### PR TITLE
Refactor profile cards with Tailwind

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -7,48 +7,53 @@ export default function CharacterCard({
   deleteLabel = 'Видалити',
 }) {
   return (
-    <div style={{ border: "1px solid #ccc", marginBottom: 12, padding: 8 }}>
+    <div className="bg-[#1c120a]/80 text-white border border-dndgold rounded-xl shadow-lg p-4 space-y-2">
       <img
-        src={character.image || "/default-avatar.png"}
+        src={character.image || '/default-avatar.png'}
         alt={character.name}
-        style={{ width: 80, height: 80, objectFit: "cover", borderRadius: 4 }}
+        className="w-20 h-20 object-cover rounded mx-auto mb-2"
       />
-      <h3>{character.name}</h3>
-      <div>
-        <strong>Раса:</strong> {character.race?.name || "—"}
+      <h3 className="text-xl text-dndgold text-center font-dnd mb-2">{character.name}</h3>
+      <div className="text-sm">
+        <strong className="text-dndgold">Раса:</strong> {character.race?.name || '—'}
       </div>
-      <div>
-        <strong>Клас:</strong> {character.profession?.name || "—"}
+      <div className="text-sm">
+        <strong className="text-dndgold">Клас:</strong> {character.profession?.name || '—'}
       </div>
-      <div>
-        <strong>Опис:</strong> {character.description || "—"}
+      <div className="text-sm">
+        <strong className="text-dndgold">Опис:</strong> {character.description || '—'}
       </div>
-      <div style={{ marginTop: 8 }}>
-        <div><strong>Стати:</strong></div>
+      <div className="mt-2">
+        <div className="text-dndgold font-semibold mb-1">Стати:</div>
         {character.stats && (
-          <ul style={{ listStyle: "none", paddingLeft: 0 }}>
+          <ul className="list-none pl-0 text-sm space-y-0.5">
             {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>{key}: {val}</li>
             ))}
           </ul>
         )}
       </div>
-      <div style={{ marginTop: 8 }}>
-        <div><strong>Інвентар:</strong></div>
-        <ul style={{ listStyle: "none", paddingLeft: 0 }}>
+      <div className="mt-2">
+        <div className="text-dndgold font-semibold mb-1">Інвентар:</div>
+        <ul className="list-none pl-0 text-sm space-y-0.5">
           {character.inventory && character.inventory.map((it, idx) => (
-            <li key={idx}>{it.item} {it.amount > 1 ? `x${it.amount}` : ""}</li>
+            <li key={idx}>{it.item} {it.amount > 1 ? `x${it.amount}` : ''}</li>
           ))}
         </ul>
       </div>
-      <div style={{ marginTop: 8 }}>
+      <div className="mt-3 flex gap-2 justify-center">
         {onEdit && (
-          <button onClick={() => onEdit(character)}>{editLabel}</button>
+          <button
+            onClick={() => onEdit(character)}
+            className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-3 py-1 transition"
+          >
+            {editLabel}
+          </button>
         )}
         {onDelete && (
           <button
-            style={{ marginLeft: 8 }}
             onClick={() => onDelete(character._id || character.id)}
+            className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-3 py-1 transition"
           >
             {deleteLabel}
           </button>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -52,11 +52,11 @@ const ProfilePage = () => {
       >
         Створити нового
       </button>
-      <ul className="w-full max-w-xl space-y-3">
+      <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl">
         {characters.length === 0 ? (
-          <li className="text-center text-dndgold/80">
+          <div className="col-span-full text-center text-dndgold/80">
             Тут поки пусто. Створи першого героя!
-          </li>
+          </div>
         ) : (
           characters.map((char) => (
             <CharacterCard
@@ -68,7 +68,7 @@ const ProfilePage = () => {
             />
           ))
         )}
-      </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- restyle `CharacterCard` using Tailwind classes for background, borders and text
- display character cards in a responsive grid on the profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be80563e083229fcc2f081907930f