### PR TITLE
Remove unused PostCSS CJS config

### DIFF
--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Summary
- drop the unused `postcss.config.cjs`
- keep the ESM `postcss.config.js`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684befa74d00832298884ccfe487d423