### PR TITLE
Add admin inventory editor

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import ProfilePage from './pages/ProfilePage';
 import CharacterCreatePage from './pages/CharacterCreatePage';
 import LobbyPage from './pages/LobbyPage';
 import AdminPage from './pages/AdminPage';
+import AdminInventoryPage from './pages/admin/AdminInventoryPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
@@ -19,6 +20,7 @@ const App = () => (
     <Route path="/create-character" element={isAuthenticated() ? <CharacterCreatePage /> : <Navigate to="/login" />} />
     <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
     <Route path="/admin" element={isAuthenticated() ? <AdminPage /> : <Navigate to="/login" />} />
+    <Route path="/admin/inventory/:characterId" element={isAuthenticated() ? <AdminInventoryPage /> : <Navigate to="/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
     <Route path="*" element={<Navigate to="/" />} />
   </Routes>

--- a/frontend/src/pages/admin/AdminInventoryPage.jsx
+++ b/frontend/src/pages/admin/AdminInventoryPage.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import api from '../../api/axios';
+import { useUserStore } from '../../store/user';
+import InventoryEditor from '../../components/InventoryEditor';
+
+export default function AdminInventoryPage() {
+  const { characterId } = useParams();
+  const { token } = useUserStore();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchInventory = async () => {
+      setLoading(true);
+      try {
+        const res = await api.get(`/inventory/${characterId}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        const data = res.data?.items || [];
+        setItems(data.map(it => it.name || it.item || it));
+      } catch (err) {
+        setItems([]);
+      }
+      setLoading(false);
+    };
+    fetchInventory();
+  }, [characterId, token]);
+
+  const handleSave = async () => {
+    await api.put(
+      `/inventory/${characterId}`,
+      { items: items.map(name => ({ name })) },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    alert('Збережено');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-dndbg p-4">
+      <div className="bg-[#322018]/90 p-8 rounded-2xl shadow-dnd w-full max-w-xl">
+        <h1 className="font-dnd text-2xl text-dndgold mb-4">Редагування інвентарю</h1>
+        {loading ? (
+          <div className="text-center text-dndgold">Завантаження...</div>
+        ) : (
+          <InventoryEditor inventory={items} onChange={setItems} />
+        )}
+        <button
+          onClick={handleSave}
+          className="mt-4 bg-dndgold text-dndred font-dnd rounded-2xl px-4 py-2"
+        >
+          Зберегти
+        </button>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">
+          ← Назад
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -3,3 +3,4 @@ export { default as AdminProfessionsPage } from './AdminProfessionsPage';
 export { default as AdminCharacteristicsPage } from './AdminCharacteristicsPage';
 export { default as AdminMapsPage } from './AdminMapsPage';
 export { default as AdminMusicPage } from './AdminMusicPage';
+export { default as AdminInventoryPage } from './AdminInventoryPage';

--- a/frontend/src/routes/AdminRoutes.jsx
+++ b/frontend/src/routes/AdminRoutes.jsx
@@ -4,6 +4,7 @@ import {
   AdminCharacteristicsPage,
   AdminMapsPage,
   AdminMusicPage,
+  AdminInventoryPage,
 } from '../pages/admin';
 
 export default function AdminRoutes() {
@@ -14,6 +15,7 @@ export default function AdminRoutes() {
       <Route path="characteristics" element={<AdminCharacteristicsPage />} />
       <Route path="maps" element={<AdminMapsPage />} />
       <Route path="music" element={<AdminMusicPage />} />
+      <Route path="inventory/:characterId" element={<AdminInventoryPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add an AdminInventoryPage for editing inventories
- expose the new page through routes and exports
- include admin inventory route in app router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf674259c83229f8f3dbfe7e385d9