### PR TITLE
Require description after character creation

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -1,13 +1,16 @@
 
 import { withApiHost } from '../utils/imageUtils';
+import { useState } from 'react';
 
 export default function CharacterCard({
   character,
   onEdit,
   onDelete,
+  onSaveDescription,
   editLabel = 'Редагувати',
   deleteLabel = 'Видалити',
 }) {
+  const [desc, setDesc] = useState(character.description || '');
   return (
     <div className="bg-[#1c120a]/80 text-white border border-dndgold rounded-xl shadow-lg p-4 space-y-2">
       <img
@@ -23,8 +26,25 @@ export default function CharacterCard({
         <strong className="text-dndgold">Клас:</strong> {character.profession?.name || '—'}
       </div>
       <div className="text-sm">
-        <strong className="text-dndgold">Опис:</strong> {character.description || '—'}
+        <strong className="text-dndgold">Опис:</strong>{' '}
+        {character.description ? (
+          <span>{character.description}</span>
+        ) : (
+          <textarea
+            className="w-full mt-1 px-2 py-1 rounded bg-[#2c1a12] border border-dndgold text-white"
+            value={desc}
+            onChange={e => setDesc(e.target.value)}
+          />
+        )}
       </div>
+      {!character.description && (
+        <button
+          onClick={() => onSaveDescription && onSaveDescription(character._id || character.id, desc)}
+          className="bg-dndgold text-dndred font-dnd rounded-2xl px-3 py-1 mt-1"
+        >
+          Зберегти опис
+        </button>
+      )}
       <div className="mt-2">
         <div className="text-dndgold font-semibold mb-1">Стати:</div>
         {character.stats && (
@@ -47,7 +67,8 @@ export default function CharacterCard({
         {onEdit && (
           <button
             onClick={() => onEdit(character)}
-            className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-3 py-1 transition"
+            disabled={!character.description}
+            className={`bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-3 py-1 transition ${!character.description ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             {editLabel}
           </button>

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -5,7 +5,7 @@ import LogoutButton from "../components/LogoutButton";
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: "", description: "" });
+  const [form, setForm] = useState({ name: "" });
   const [image, setImage] = useState(null);
   const [error, setError] = useState(null);
 
@@ -15,8 +15,8 @@ export default function CharacterCreatePage() {
 
   const handleSubmit = async () => {
     try {
-      if (!form.name || !form.description) {
-        setError("Будь ласка, заповніть всі поля.");
+      if (!form.name) {
+        setError("Будь ласка, заповніть ім'я персонажа.");
         return;
       }
 
@@ -25,11 +25,10 @@ export default function CharacterCreatePage() {
       if (image) {
         payload = new FormData();
         payload.append('name', form.name);
-        payload.append('description', form.description);
         payload.append('image', image);
         headers = { 'Content-Type': 'multipart/form-data' };
       } else {
-        payload = { name: form.name, description: form.description };
+        payload = { name: form.name };
         headers = { 'Content-Type': 'application/json' };
       }
       await api.post("/character", payload, { headers });
@@ -57,13 +56,6 @@ export default function CharacterCreatePage() {
         <input
           name="name"
           value={form.name}
-          onChange={handleChange}
-          className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
-        />
-        <label className="block text-sm mb-1">Опис</label>
-        <textarea
-          name="description"
-          value={form.description}
           onChange={handleChange}
           className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
         />

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LogoutButton from '../components/LogoutButton';
 import CharacterCard from '../components/CharacterCard';
-import { getCharacters, deleteCharacter } from '../utils/api';
+import { getCharacters, deleteCharacter, updateCharacter } from '../utils/api';
 
 const ProfilePage = () => {
   const [characters, setCharacters] = useState([]);
@@ -29,6 +29,11 @@ const ProfilePage = () => {
   const handleDelete = async (id) => {
     await deleteCharacter(id);
     setCharacters((prev) => prev.filter((c) => c._id !== id));
+  };
+
+  const handleSaveDescription = async (id, desc) => {
+    const updated = await updateCharacter(id, { description: desc });
+    setCharacters(prev => prev.map(c => c._id === id ? updated : c));
   };
 
   return (
@@ -65,6 +70,7 @@ const ProfilePage = () => {
               editLabel="Увійти"
               onEdit={() => handleSelect(char._id)}
               onDelete={() => handleDelete(char._id)}
+              onSaveDescription={handleSaveDescription}
             />
           ))
         )}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -43,3 +43,23 @@ export const deleteCharacter = async (id) => {
   });
   return res.json();
 };
+
+export const updateCharacter = async (id, data) => {
+  const headers = getAuthHeaders();
+  let body;
+  if (data.image instanceof File) {
+    body = new FormData();
+    Object.keys(data).forEach(key => {
+      if (data[key] !== undefined) body.append(key, data[key]);
+    });
+  } else {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(data);
+  }
+  const res = await fetch(`${API_URL}/character/${id}`, {
+    method: 'PUT',
+    headers,
+    body,
+  });
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- remove description input from `CharacterCreatePage`
- allow editing description in `CharacterCard`
- disable lobby join if description is missing
- update profile page to save descriptions
- add API helper for updating characters

## Testing
- `npm install --quiet` in backend
- `npm test` in backend *(passes)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bf5417f9c832287322daf4ca9a1d8