### PR TITLE
Add character data to lobby and table sessions

### DIFF
--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -9,10 +9,10 @@ export default function PlayerCard({ character, onSelect }) {
       <img src={withApiHost(character.image) || "/default-avatar.png"} alt="character" className="rounded mb-2 h-32 w-full object-cover" />
       <h3 className="text-xl text-dndgold">{character.name}</h3>
       <p className="text-sm">
-        Раса: {t('races.' + (character.race || '')) || character.race}
+        Раса: {t('races.' + (character.race?.name || '')) || character.race?.name}
       </p>
       <p className="text-sm">
-        Клас: {t('classes.' + (character.class || '')) || character.class}
+        Клас: {t('classes.' + (character.profession?.name || '')) || character.profession?.name}
       </p>
       <button onClick={() => onSelect(character)} className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700">Грати</button>
     </div>

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -6,7 +6,7 @@ import PlayerCard from "../components/PlayerCard";
 import MusicPlayer from "../components/MusicPlayer";
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { useUserStore } from '../store/user'
 
 // socket connection URL configurable via env
@@ -15,6 +15,8 @@ const socket = io(import.meta.env.VITE_SOCKET_URL);
 export default function GameTablePage() {
   const { user } = useUserStore();
   const { tableId } = useParams();
+  const [searchParams] = useSearchParams();
+  const characterId = searchParams.get('char');
   const [players, setPlayers] = useState([]);
   const [gm, setGm] = useState(null);
   const [monsters, setMonsters] = useState([]);
@@ -26,7 +28,7 @@ export default function GameTablePage() {
 
   // SOCKET.IO підключення
   useEffect(() => {
-    socket.emit("join-table", { tableId, user });
+    socket.emit("join-table", { tableId, user, characterId });
     socket.on("table-players", data => {
       setPlayers(data.players || []);
       setGm(data.gm || null);
@@ -39,7 +41,7 @@ export default function GameTablePage() {
     socket.on("chat-history", setMessages);
     socket.on("chat-message", msg => setMessages(m => [...m, msg]));
     return () => socket.disconnect();
-  }, [tableId, user]);
+  }, [tableId, user, characterId]);
 
   // Кубики
   const rollDice = (type = "d20") => {
@@ -78,7 +80,7 @@ export default function GameTablePage() {
         {/* Ліва панель: твій персонаж і монстри */}
         <div className="w-1/6 p-2">
           {myPlayer
-            ? <PlayerCard character={myPlayer} />
+            ? <PlayerCard character={myPlayer.character} />
             : (
               <div className="bg-[#25160f]/80 rounded-2xl p-4 mb-4 text-dndgold">
                 <div className="text-lg font-bold mb-2">Твій персонаж</div>

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -29,7 +29,7 @@ export default function LobbyPage() {
       return;
     }
     setError('');
-    socket.emit('join-lobby', { tableId, user, char });
+    socket.emit('join-lobby', { tableId, user, characterId: char });
     socket.on('lobby-players', data => setPlayers(data.players));
     socket.on('gm-assigned', () => setIsGM(true));
     socket.on('game-started', () => navigate(`/table/${tableId}`));
@@ -61,7 +61,10 @@ export default function LobbyPage() {
         <div className="text-dndgold mb-4">Гравці:</div>
         <ul>
           {players.map(pl => (
-            <li key={pl._id} className="text-dndgold">{pl.name} {pl.role === "gm" ? "(GM)" : ""}</li>
+            <li key={pl.user} className="text-dndgold">
+              {pl.character?.name || pl.user}
+              {pl.role === "gm" ? "(GM)" : ""}
+            </li>
           ))}
         </ul>
         {isGM && (


### PR DESCRIPTION
## Summary
- include Character model in socket handling
- fetch characters when players join lobby/table
- send players with character info to clients
- adjust PlayerCard to use profession/race objects
- expect player.character in LobbyPage and GameTablePage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0307484483229e379b59fddd266d