### PR TITLE
Add randomized inventory with bonuses

### DIFF
--- a/backend/src/models/Character.js
+++ b/backend/src/models/Character.js
@@ -15,7 +15,8 @@ const characterSchema = new mongoose.Schema({
   },
   inventory: [{
     item: { type: String },
-    amount: { type: Number, default: 1 }
+    amount: { type: Number, default: 1 },
+    bonus: { type: Map, of: Number, default: {} }
   }],
   description: { type: String, default: '' },
   image: { type: String, default: '' }, // посилання на файл/URL

--- a/backend/src/models/Inventory.js
+++ b/backend/src/models/Inventory.js
@@ -4,9 +4,10 @@ const mongoose = require('mongoose');
 const inventorySchema = new mongoose.Schema({
   character: { type: mongoose.Schema.Types.ObjectId, ref: 'Character', required: true },
   items: [{
-    name: { type: String, required: true },
+    item: { type: String, required: true },
     amount: { type: Number, default: 1 },
-    description: { type: String, default: '' }
+    description: { type: String, default: '' },
+    bonus: { type: Map, of: Number, default: {} }
   }]
 }, { timestamps: true });
 

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,30 +1,128 @@
 const classInventory = {
-  Warrior: ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я'],
-  Mage: ['Магічний посох', 'Книга заклять', 'Мана-зілля'],
-  Rogue: ['Кинджал', 'Плащ тіні', 'Відмички'],
-  Healer: ['Жезл лікування', 'Зілля лікування', 'Травник'],
-  Ranger: ['Лук', 'Колчан стріл', 'Ніж для виживання'],
-  Bard: ['Лютня', 'Легкий меч', 'Пісенник'],
-  Paladin: ['Молот', 'Латна броня', 'Святий амулет'],
+  Warrior: {
+    weapon: [
+      { item: 'Меч', amount: 1, bonus: { STR: 2 } },
+      { item: 'Сокира', amount: 1, bonus: { STR: 2 } }
+    ],
+    armor: [
+      { item: 'Щит', amount: 1, bonus: { CON: 1 } },
+      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } }
+    ],
+    misc: [
+      { item: 'Зілля здоров’я', amount: 1 }
+    ]
+  },
+  Mage: {
+    weapon: [
+      { item: 'Магічний посох', amount: 1, bonus: { INT: 2 } },
+      { item: 'Чарівна паличка', amount: 1, bonus: { INT: 1 } }
+    ],
+    armor: [
+      { item: 'Обруч мудрості', amount: 1, bonus: { INT: 1 } },
+      { item: 'Тканинна мантія', amount: 1, bonus: { CON: 1 } }
+    ],
+    misc: [
+      { item: 'Мана-зілля', amount: 1 },
+      { item: 'Книга заклять', amount: 1 }
+    ]
+  },
+  Rogue: {
+    weapon: [
+      { item: 'Кинджал', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Короткий меч', amount: 1, bonus: { DEX: 1 } }
+    ],
+    armor: [
+      { item: 'Плащ тіні', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Легка броня', amount: 1, bonus: { DEX: 1 } }
+    ],
+    misc: [
+      { item: 'Відмички', amount: 1 }
+    ]
+  },
+  Healer: {
+    weapon: [
+      { item: 'Жезл лікування', amount: 1, bonus: { CHA: 1 } },
+      { item: 'Священний посох', amount: 1, bonus: { CHA: 1 } }
+    ],
+    armor: [
+      { item: 'Легка ряса', amount: 1, bonus: { CON: 1 } },
+      { item: 'Травник', amount: 1 }
+    ],
+    misc: [
+      { item: 'Зілля лікування', amount: 1 }
+    ]
+  },
+  Ranger: {
+    weapon: [
+      { item: 'Лук', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Арбалет', amount: 1, bonus: { DEX: 1 } }
+    ],
+    armor: [
+      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Ніж для виживання', amount: 1 }
+    ],
+    misc: [
+      { item: 'Колчан стріл', amount: 1 }
+    ]
+  },
+  Bard: {
+    weapon: [
+      { item: 'Лютня', amount: 1, bonus: { CHA: 1 } },
+      { item: 'Легкий меч', amount: 1, bonus: { DEX: 1 } }
+    ],
+    armor: [
+      { item: 'Короткий лук', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Пісенник', amount: 1 }
+    ],
+    misc: []
+  },
+  Paladin: {
+    weapon: [
+      { item: 'Молот', amount: 1, bonus: { STR: 1 } },
+      { item: 'Святий меч', amount: 1, bonus: { STR: 2 } }
+    ],
+    armor: [
+      { item: 'Латна броня', amount: 1, bonus: { CON: 2 } },
+      { item: 'Святий щит', amount: 1, bonus: { CHA: 1 } }
+    ],
+    misc: [
+      { item: 'Святий амулет', amount: 1 }
+    ]
+  }
 };
 
 const raceInventory = {
-  Elf: ['Ельфійські стріли'],
-  Orc: ['Кістяний талісман'],
-  Human: ['Монета удачі'],
-  Gnome: ['Гвинтовий ключ'],
-  Dwarf: ['Похідна кружка'],
-  Halfling: ['Трубка та тютюн'],
-  Demon: ['Темний камінь'],
-  Beastkin: ['Кігтістий амулет'],
-  Angel: ['Пір’я з крила'],
-  Lizardman: ['Луска пращура'],
+  Elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
+  Orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
+  Human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
+  Gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
+  Dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
+  Halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
+  Demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
+  Beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
+  Angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
+  Lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }]
 };
 
+function randomItem(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
 function generateInventory(race, charClass) {
-  const classItems = classInventory[charClass] || [];
+  const result = [];
+  const classItems = classInventory[charClass] || {};
+  for (const category of Object.keys(classItems)) {
+    const options = classItems[category];
+    if (Array.isArray(options) && options.length) {
+      const choice = randomItem(options);
+      result.push({ item: choice.item, amount: choice.amount ?? 1, bonus: choice.bonus || {} });
+    }
+  }
   const raceItems = raceInventory[race] || [];
-  return [...classItems, ...raceItems].map(name => ({ item: name, amount: 1 }));
+  for (const r of raceItems) {
+    result.push({ item: r.item, amount: r.amount ?? 1, bonus: r.bonus || {} });
+  }
+  return result;
 }
 
 module.exports = generateInventory;

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,13 +1,39 @@
 const generateInventory = require('../src/utils/generateInventory');
 
 describe('generateInventory', () => {
-  it('combines items from class and race', () => {
+  it('selects random items for each category', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0);
+
     const items = generateInventory('Orc', 'Warrior');
+    Math.random.mockRestore();
+
     const names = items.map(i => i.item);
     expect(names).toEqual([
       'Меч',
-      'Щит',
       'Шкіряна броня',
+      'Зілля здоров’я',
+      'Кістяний талісман'
+    ]);
+  });
+
+  it('mixes items across sets', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0);
+
+    const items = generateInventory('Orc', 'Warrior');
+    Math.random.mockRestore();
+
+    const names = items.map(i => i.item);
+    expect(names).toEqual([
+      'Сокира',
+      'Щит',
       'Зілля здоров’я',
       'Кістяний талісман'
     ]);

--- a/backend/tests/inventory.test.js
+++ b/backend/tests/inventory.test.js
@@ -12,11 +12,11 @@ beforeEach(() => {
 describe('Inventory Controller - update', () => {
   it('allows owner to update inventory', async () => {
     Character.findOne.mockResolvedValue({ _id: 'c1', user: 'u1' });
-    Inventory.findOneAndUpdate.mockResolvedValue({ items: [{ name: 'Sword' }] });
+    Inventory.findOneAndUpdate.mockResolvedValue({ items: [{ item: 'Sword' }] });
 
     const req = {
       params: { characterId: 'c1' },
-      body: { items: [{ name: 'Sword' }] },
+      body: { items: [{ item: 'Sword' }] },
       user: { id: 'u1', role: 'player' }
     };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -24,7 +24,7 @@ describe('Inventory Controller - update', () => {
     await inventoryController.update(req, res);
 
     expect(Inventory.findOneAndUpdate).toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith({ items: [{ name: 'Sword' }] });
+    expect(res.json).toHaveBeenCalledWith({ items: [{ item: 'Sword' }] });
   });
 
   it('allows admin to update inventory without ownership', async () => {

--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -65,9 +65,18 @@ export default function CharacterCard({
       <div className="mt-2">
         <div className="text-dndgold font-semibold mb-1">Інвентар:</div>
         <ul className="list-none pl-0 text-base space-y-0.5">
-          {character.inventory && character.inventory.map((it, idx) => (
-            <li key={idx}>{it.item} {it.amount > 1 ? `x${it.amount}` : ''}</li>
-          ))}
+          {character.inventory && character.inventory.map((it, idx) => {
+            const bonus = it.bonus && Object.keys(it.bonus).length
+              ? ' (' + Object.entries(it.bonus)
+                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${k}`)
+                  .join(', ') + ')'
+              : '';
+            return (
+              <li key={idx}>
+                {it.item} {it.amount > 1 ? `x${it.amount}` : ''}{bonus}
+              </li>
+            );
+          })}
         </ul>
       </div>
       <div className="mt-3 flex gap-2 justify-center">

--- a/frontend/src/utils/characterUtils.js
+++ b/frontend/src/utils/characterUtils.js
@@ -21,26 +21,109 @@ export const classes = [
 ];
 
 const classInventory = {
-  Warrior: ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я'],
-  Mage: ['Магічний посох', 'Книга заклять', 'Мана-зілля'],
-  Rogue: ['Кинджал', 'Плащ тіні', 'Відмички'],
-  Healer: ['Жезл лікування', 'Зілля лікування', 'Травник'],
-  Ranger: ['Лук', 'Колчан стріл', 'Ніж для виживання'],
-  Bard: ['Лютня', 'Легкий меч', 'Пісенник'],
-  Paladin: ['Молот', 'Латна броня', 'Святий амулет'],
+  Warrior: {
+    weapon: [
+      { item: 'Меч', amount: 1, bonus: { STR: 2 } },
+      { item: 'Сокира', amount: 1, bonus: { STR: 2 } },
+    ],
+    armor: [
+      { item: 'Щит', amount: 1, bonus: { CON: 1 } },
+      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } },
+    ],
+    misc: [
+      { item: 'Зілля здоров’я', amount: 1 },
+    ],
+  },
+  Mage: {
+    weapon: [
+      { item: 'Магічний посох', amount: 1, bonus: { INT: 2 } },
+      { item: 'Чарівна паличка', amount: 1, bonus: { INT: 1 } },
+    ],
+    armor: [
+      { item: 'Обруч мудрості', amount: 1, bonus: { INT: 1 } },
+      { item: 'Тканинна мантія', amount: 1, bonus: { CON: 1 } },
+    ],
+    misc: [
+      { item: 'Мана-зілля', amount: 1 },
+      { item: 'Книга заклять', amount: 1 },
+    ],
+  },
+  Rogue: {
+    weapon: [
+      { item: 'Кинджал', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Короткий меч', amount: 1, bonus: { DEX: 1 } },
+    ],
+    armor: [
+      { item: 'Плащ тіні', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Легка броня', amount: 1, bonus: { DEX: 1 } },
+    ],
+    misc: [
+      { item: 'Відмички', amount: 1 },
+    ],
+  },
+  Healer: {
+    weapon: [
+      { item: 'Жезл лікування', amount: 1, bonus: { CHA: 1 } },
+      { item: 'Священний посох', amount: 1, bonus: { CHA: 1 } },
+    ],
+    armor: [
+      { item: 'Легка ряса', amount: 1, bonus: { CON: 1 } },
+      { item: 'Травник', amount: 1 },
+    ],
+    misc: [
+      { item: 'Зілля лікування', amount: 1 },
+    ],
+  },
+  Ranger: {
+    weapon: [
+      { item: 'Лук', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Арбалет', amount: 1, bonus: { DEX: 1 } },
+    ],
+    armor: [
+      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Ніж для виживання', amount: 1 },
+    ],
+    misc: [
+      { item: 'Колчан стріл', amount: 1 },
+    ],
+  },
+  Bard: {
+    weapon: [
+      { item: 'Лютня', amount: 1, bonus: { CHA: 1 } },
+      { item: 'Легкий меч', amount: 1, bonus: { DEX: 1 } },
+    ],
+    armor: [
+      { item: 'Короткий лук', amount: 1, bonus: { DEX: 1 } },
+      { item: 'Пісенник', amount: 1 },
+    ],
+    misc: [],
+  },
+  Paladin: {
+    weapon: [
+      { item: 'Молот', amount: 1, bonus: { STR: 1 } },
+      { item: 'Святий меч', amount: 1, bonus: { STR: 2 } },
+    ],
+    armor: [
+      { item: 'Латна броня', amount: 1, bonus: { CON: 2 } },
+      { item: 'Святий щит', amount: 1, bonus: { CHA: 1 } },
+    ],
+    misc: [
+      { item: 'Святий амулет', amount: 1 },
+    ],
+  },
 };
 
 const raceInventory = {
-  Elf: ['Ельфійські стріли'],
-  Orc: ['Кістяний талісман'],
-  Human: ['Монета удачі'],
-  Gnome: ['Гвинтовий ключ'],
-  Dwarf: ['Похідна кружка'],
-  Halfling: ['Трубка та тютюн'],
-  Demon: ['Темний камінь'],
-  Beastkin: ['Кігтістий амулет'],
-  Angel: ['Пір’я з крила'],
-  Lizardman: ['Луска пращура'],
+  Elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
+  Orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
+  Human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
+  Gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
+  Dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
+  Halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
+  Demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
+  Beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
+  Angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
+  Lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }],
 };
 
 
@@ -85,7 +168,18 @@ export const getRandomStats = (charClass) => {
 };
 
 export const generateInventory = (race, charClass) => {
-  const classItems = classInventory[charClass] || [];
+  const result = [];
+  const classItems = classInventory[charClass] || {};
+  Object.keys(classItems).forEach(cat => {
+    const opts = classItems[cat];
+    if (Array.isArray(opts) && opts.length) {
+      const choice = getRandomElement(opts);
+      result.push({ item: choice.item, amount: choice.amount ?? 1, bonus: choice.bonus || {} });
+    }
+  });
   const raceItems = raceInventory[race] || [];
-  return [...classItems, ...raceItems];
+  raceItems.forEach(it => {
+    result.push({ item: it.item, amount: it.amount ?? 1, bonus: it.bonus || {} });
+  });
+  return result;
 };


### PR DESCRIPTION
## Summary
- support bonus field for character and inventory items
- randomize inventory items per category
- display item bonuses on character card
- update tests for new inventory logic

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c03098e1083228d6c782cff912ed6