### PR TITLE
Add admin auth flow

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -4,6 +4,8 @@ const mongoose = require('mongoose');
 const Race = require('../src/models/Race');
 const Profession = require('../src/models/Profession');
 const Characteristic = require('../src/models/Characteristic');
+const User = require('../src/models/User');
+const bcrypt = require('bcrypt');
 
 const MONGO_URI = process.env.MONGO_URI;
 
@@ -85,6 +87,18 @@ async function seed() {
   if (await Characteristic.countDocuments() === 0) {
     await Characteristic.insertMany(characteristics.map(name => ({ name })));
     console.log('Characteristics seeded');
+  }
+
+  const adminLogin = 'root';
+  if (await User.countDocuments({ login: adminLogin }) === 0) {
+    const hash = await bcrypt.hash('kolokol911', 10);
+    await User.create({
+      login: adminLogin,
+      username: 'Admin',
+      password: hash,
+      role: 'admin'
+    });
+    console.log('Admin user created');
   }
 
   await mongoose.disconnect();

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -38,6 +38,7 @@ app.use('/uploads', express.static(uploadDir));
 
 // API routes
 app.use('/api/auth', require('./routes/auth'));
+app.use('/api/admin/auth', require('./routes/adminAuth'));
 app.use('/api/character', require('./routes/character'));
 app.use('/api/characteristic', require('./routes/characteristic'));
 app.use('/api/inventory', require('./routes/inventory'));

--- a/backend/src/routes/adminAuth.js
+++ b/backend/src/routes/adminAuth.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const router = express.Router();
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
+async function loginHandler(req, res) {
+  try {
+    const { login, password } = req.body;
+    if (!login || !password) {
+      return res.status(400).json({ message: 'Login and password are required' });
+    }
+
+    const user = await User.findOne({ login });
+    if (!user || user.role !== 'admin') {
+      return res.status(404).json({ message: 'Admin not found' });
+    }
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: 'Invalid password' });
+    }
+
+    const token = jwt.sign(
+      { _id: user._id, login: user.login, username: user.username, role: 'admin' },
+      JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    res.json({
+      token,
+      user: {
+        _id: user._id,
+        login: user.login,
+        username: user.username,
+        role: user.role,
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Login error', error: err.message });
+  }
+}
+
+router.post('/login', loginHandler);
+router.post('/', loginHandler);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,19 +9,29 @@ import AdminPage from './pages/AdminPage';
 import AdminInventoryPage from './pages/admin/AdminInventoryPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
+import AdminLoginPage from './pages/AdminLoginPage';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
+const isAdmin = () => {
+  try {
+    const data = JSON.parse(localStorage.getItem('user-storage') || '{}');
+    return data.state?.user?.role === 'admin';
+  } catch {
+    return false;
+  }
+};
 
 const App = () => (
   <Routes>
     <Route path="/" element={<Navigate to={isAuthenticated() ? "/profile" : "/login"} />} />
     <Route path="/login" element={<LoginPage />} />
+    <Route path="/admin/login" element={<AdminLoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
     <Route path="/profile" element={isAuthenticated() ? <ProfilePage /> : <Navigate to="/login" />} />
     <Route path="/create-character" element={isAuthenticated() ? <CharacterCreatePage /> : <Navigate to="/login" />} />
     <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
-    <Route path="/admin" element={isAuthenticated() ? <AdminPage /> : <Navigate to="/login" />} />
-    <Route path="/admin/inventory/:characterId" element={isAuthenticated() ? <AdminInventoryPage /> : <Navigate to="/login" />} />
+    <Route path="/admin" element={isAdmin() ? <AdminPage /> : <Navigate to="/admin/login" />} />
+    <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
     <Route path="/table/:tableId" element={<GameTablePage />} />
     <Route path="*" element={<Navigate to="/" />} />

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -1,0 +1,70 @@
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '../context/ToastContext';
+import { useTranslation } from 'react-i18next';
+import { useUserStore } from '../store/user';
+import { useState } from 'react';
+import api from "../api/axios";
+
+function AdminLoginPage() {
+  const [login, setLogin] = useState('');
+  const [password, setPassword] = useState('');
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [error, setError] = useState('');
+  const setUser = useUserStore((s) => s.setUser);
+
+  const handleSubmit = async (e) => {
+    setError(null);
+    if (!login || !password) {
+      showToast(t('fields_required'), 'error');
+      return;
+    }
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await api.post('/admin/auth', { login, password });
+      setUser(res.data.user, res.data.token);
+      navigate('/admin');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div
+      className="min-h-screen bg-cover bg-center flex items-center justify-center"
+      style={{ backgroundImage: `url('/map-bg.jpg')` }}
+    >
+      <div className="bg-[#2d1d14]/90 p-8 rounded-lg shadow-lg w-full max-w-md text-center text-white">
+        <h1 className="text-3xl font-dnd mb-4">Admin Login</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {error && <div className="text-red-400">{error}</div>}
+          <input
+            className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
+            placeholder="Login"
+            value={login}
+            onChange={(e) => setLogin(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
+            placeholder="••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button
+            type="submit"
+            className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold"
+          >
+            {t('login')}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default AdminLoginPage;


### PR DESCRIPTION
## Summary
- seed root admin user
- add adminAuth login route and mount it
- implement admin login page
- add admin login route and isAdmin guard in frontend

## Testing
- `npm install` in backend
- `npm test` in backend
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c04d633b08322bcf296538946c906