### PR TITLE
Update register flow to use login as username

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -8,9 +8,12 @@ const JWT_SECRET = process.env.JWT_SECRET;
 exports.register = async (req, res) => {
   try {
     const { login, password, username } = req.body;
-    if (!login || !password || !username) {
-      return res.status(400).json({ message: "Login, password and username are required" });
+    if (!login || !password) {
+      return res.status(400).json({ message: "Login and password are required" });
     }
+
+    // Default username to login if not provided
+    const finalUsername = username || login;
 
     const candidate = await User.findOne({ login });
     if (candidate) {
@@ -18,7 +21,7 @@ exports.register = async (req, res) => {
     }
 
     const hash = await bcrypt.hash(password, 10);
-    const user = new User({ login, password: hash, username });
+    const user = new User({ login, password: hash, username: finalUsername });
     await user.save();
 
     res.status(201).json({

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next'
 function RegisterPage() {
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
-  const [username, setUsername] = useState("");
   const { showToast } = useToast();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -21,7 +20,7 @@ function RegisterPage() {
       await axios.post(`${import.meta.env.VITE_API_URL}/auth/register`, {
         login,
         password,
-        username,
+        username: login,
       });
 
       const response = await axios.post(`${import.meta.env.VITE_API_URL}/auth/login`, {
@@ -52,14 +51,6 @@ function RegisterPage() {
           placeholder="Логін"
           value={login}
           onChange={(e) => setLogin(e.target.value)}
-          className="w-full border rounded px-3 py-2 mb-3"
-          required
-        />
-        <input
-          type="text"
-          placeholder="Ім'я користувача"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
           className="w-full border rounded px-3 py-2 mb-3"
           required
         />


### PR DESCRIPTION
## Summary
- default username to login on the backend
- remove username field from registration page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0f08b59c83228a90bda2844958a9