### PR TITLE
Use axios instance in auth pages

### DIFF
--- a/frontend/src/pages/ChangePasswordPage.jsx
+++ b/frontend/src/pages/ChangePasswordPage.jsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import api from "../api/axios";
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom'
 import Navbar from "../components/Navbar";
@@ -9,21 +9,14 @@ function ChangePasswordPage() {
   const [message, setMessage] = useState("");
   const navigate = useNavigate();
 
-  const token = localStorage.getItem("token");
-
   const handleSubmit = async (e) => {
     e.preventDefault();
     setMessage("");
 
     try {
-      await axios.post(
-        `${import.meta.env.VITE_API_URL}/auth/change-password`,
-        { currentPassword, newPassword },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
+      await api.post(
+        "/auth/change-password",
+        { currentPassword, newPassword }
       );
       setMessage("Пароль успішно змінено.");
       setCurrentPassword("");

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import api from "../api/axios";
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom'
@@ -18,13 +18,13 @@ function RegisterPage() {
     setError("");
 
     try {
-      await axios.post(`${import.meta.env.VITE_API_URL}/auth/register`, {
+      await api.post("/auth/register", {
         login,
         password,
         username,
       });
 
-      const response = await axios.post(`${import.meta.env.VITE_API_URL}/auth/login`, {
+      const response = await api.post("/auth/login", {
         login,
         password,
       });


### PR DESCRIPTION
## Summary
- replace direct axios usage on auth pages with configured instance
- rely on axios interceptors for Authorization header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0f0a018883229f916d0733e8e9b6