### PR TITLE
Refactor table layout with side player slots

### DIFF
--- a/frontend/src/components/DiceBox.jsx
+++ b/frontend/src/components/DiceBox.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+export default function DiceBox() {
+  const [diceResult, setDiceResult] = useState(null);
+  const [diceAnim, setDiceAnim] = useState(false);
+
+  const rollDice = (type = 'd20') => {
+    setDiceAnim(true);
+    setTimeout(() => {
+      setDiceAnim(false);
+      const res = type === 'd20'
+        ? Math.ceil(Math.random() * 20)
+        : Math.ceil(Math.random() * 6);
+      setDiceResult(res);
+    }, 600);
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex gap-2">
+        <button
+          className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
+          onClick={() => rollDice('d20')}
+        >
+          Кинути D20
+        </button>
+        <button
+          className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
+          onClick={() => rollDice('d6')}
+        >
+          Кинути D6
+        </button>
+      </div>
+      {diceAnim && (
+        <div className="animate-bounce text-3xl text-dndgold mt-2"> ...</div>
+      )}
+      {diceResult && !diceAnim && (
+        <div className="text-xl text-dndgold font-bold mt-2">Результат: {diceResult}</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- update game table layout to centralize the board
- add a new `DiceBox` component
- move chat to bottom left and dice box to bottom right
- display up to six player cards around the board

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d69fb8080832296296f717db056a3