### PR TITLE
Fix registration username state

### DIFF
--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -11,6 +11,7 @@ function RegisterPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [error, setError] = useState("");
+  const [username, setUsername] = useState("");
 
   const handleRegister = async (e) => {
     e.preventDefault();
@@ -20,7 +21,7 @@ function RegisterPage() {
       await api.post("/auth/register", {
         login,
         password,
-        username: login,
+        username,
       });
 
       const response = await api.post("/auth/login", {
@@ -78,7 +79,6 @@ function RegisterPage() {
           </button>
         </form>
       </div>
- main
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- define username state for RegisterPage
- send username to /auth/register API
- clean up stray text in RegisterPage

## Testing
- `npm run build` in frontend
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_684d6f7e659c832281735f016f814b60