### PR TITLE
Fix registration and avatar defaults

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -23,11 +23,6 @@ exports.create = async (req, res) => {
     const { name, description, image } = req.body;
     const uploaded = req.file ? `/uploads/avatars/${req.file.filename}` : null;
 
-    // Дефолтні аватари
-
-    const defaultAvatars = [
-      "/avatars/1.png"
-    ];
 
     // Обрати рандомно расу, професію і базові стати з колекції
   let race = await Race.aggregate([{ $sample: { size: 1 } }]);
@@ -54,10 +49,7 @@ exports.create = async (req, res) => {
  
 
     // Логіка вибору аватара
-    const avatar = uploaded ||
-      ((image && image.trim())
-        ? image
-        : defaultAvatars[Math.floor(Math.random() * defaultAvatars.length)]);
+    const avatar = uploaded || (image && image.trim() ? image : '');
 
     const inventory = generateInventory(race[0].name, profession[0].name);
 

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -11,7 +11,6 @@ function RegisterPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [error, setError] = useState("");
-  const [username, setUsername] = useState("");
 
   const handleRegister = async (e) => {
     e.preventDefault();
@@ -21,7 +20,7 @@ function RegisterPage() {
       await api.post("/auth/register", {
         login,
         password,
-        username,
+        username: login,
       });
 
       const response = await api.post("/auth/login", {
@@ -52,14 +51,6 @@ function RegisterPage() {
             placeholder="Логін"
             value={login}
             onChange={(e) => setLogin(e.target.value)}
-            className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
-            required
-          />
-          <input
-            type="text"
-            placeholder="Ім'я користувача"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             required
           />


### PR DESCRIPTION
## Summary
- simplify registration flow by dropping the user name field and using the login as username
- remove unused default avatar paths and keep character image empty when none is uploaded

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d73b3e8a883229f8e923e2fbc8ebe