### PR TITLE
Add detailed player cards

### DIFF
--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -37,7 +37,7 @@ function init(httpServer) {
         if (characterId) {
           character = await Character.findById(characterId)
             .populate('race profession')
-            .select('name image race profession')
+            .select('name image race profession stats inventory description')
             .lean();
         }
         player = { user: user._id, character, online: true };
@@ -47,7 +47,7 @@ function init(httpServer) {
         if (characterId && !player.character) {
           player.character = await Character.findById(characterId)
             .populate('race profession')
-            .select('name image race profession')
+            .select('name image race profession stats inventory description')
             .lean();
         }
       }
@@ -76,7 +76,7 @@ function init(httpServer) {
         if (characterId) {
           character = await Character.findById(characterId)
             .populate('race profession')
-            .select('name image race profession')
+            .select('name image race profession stats inventory description')
             .lean();
         }
         player = { user: user._id, character, online: true };
@@ -86,7 +86,7 @@ function init(httpServer) {
         if (characterId && !player.character) {
           player.character = await Character.findById(characterId)
             .populate('race profession')
-            .select('name image race profession')
+            .select('name image race profession stats inventory description')
             .lean();
         }
       }

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -5,16 +5,44 @@ import { useTranslation } from 'react-i18next';
 export default function PlayerCard({ character, onSelect }) {
   const { t } = useTranslation();
   return (
-    <div className="border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd">
-      <img src={withApiHost(character.image) || "/default-avatar.png"} alt="character" className="rounded mb-2 h-32 w-full object-cover" />
-      <h3 className="text-xl text-dndgold">{character.name}</h3>
-      <p className="text-sm">
-        Раса: {t('races.' + (character.race?.name || '')) || character.race?.name}
+    <div className="border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd w-56">
+      <img
+        src={withApiHost(character.image) || '/default-avatar.png'}
+        alt="character"
+        className="rounded mb-2 h-28 w-full object-cover"
+      />
+      <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
+      <p className="text-xs text-center">
+        {t('races.' + (character.race?.name || '')) || character.race?.name} /{' '}
+        {t('classes.' + (character.profession?.name || '')) || character.profession?.name}
       </p>
-      <p className="text-sm">
-        Клас: {t('classes.' + (character.profession?.name || '')) || character.profession?.name}
-      </p>
-      <button onClick={() => onSelect(character)} className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700">Грати</button>
+      {character.stats && (
+        <ul className="text-xs grid grid-cols-2 gap-x-2 mt-2">
+          {Object.entries(character.stats).map(([key, val]) => (
+            <li key={key}>
+              {t('stats.' + key) || key}: {val}
+            </li>
+          ))}
+        </ul>
+      )}
+      {character.inventory && character.inventory.length > 0 && (
+        <ul className="text-xs list-disc pl-4 mt-2 space-y-0.5">
+          {character.inventory.map((it, idx) => (
+            <li key={idx}>
+              {it.item}
+              {it.amount > 1 ? ` x${it.amount}` : ''}
+            </li>
+          ))}
+        </ul>
+      )}
+      {onSelect && (
+        <button
+          onClick={() => onSelect(character)}
+          className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700"
+        >
+          Грати
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- include stats/inventory details when sending character data via sockets
- show stats and inventory on PlayerCard if available

## Testing
- `npm --prefix backend test` *(fails: jest not found)*
- `npm --prefix frontend test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d75b880c48322a20b5977757c5059