### PR TITLE
Fix MusicPlayer user store import

### DIFF
--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -1,6 +1,7 @@
 import ReactPlayer from 'react-player';
 import { useState, useEffect } from 'react';
 import api from '../api/axios';
+import { useUserStore } from '../store/user';
 
 export default function MusicPlayer({ isGM }) {
   const { token } = useUserStore();


### PR DESCRIPTION
## Summary
- add missing user store import in `MusicPlayer`

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684d83688dc48322962114422a6361b6