### PR TITLE
Fix onlyMaster middleware usage

### DIFF
--- a/backend/src/middleware/onlyMaster.js
+++ b/backend/src/middleware/onlyMaster.js
@@ -1,4 +1,8 @@
-module.exports = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
+function onlyMaster(req, res, next) {
+  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) {
+    return next();
+  }
   return res.status(403).json({ message: 'Forbidden' });
-};
+}
+
+module.exports = onlyMaster;

--- a/backend/src/middleware/onlyMaster.js
+++ b/backend/src/middleware/onlyMaster.js
@@ -1,8 +1,0 @@
-function onlyMaster(req, res, next) {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) {
-    return next();
-  }
-  return res.status(403).json({ message: 'Forbidden' });
-}
-
-module.exports = onlyMaster;

--- a/backend/src/routes/characteristic.js
+++ b/backend/src/routes/characteristic.js
@@ -3,10 +3,7 @@ const router = express.Router();
 const characteristicController = require('../controllers/characteristicController');
 const auth = require('../middleware/authMiddleware');
 
-const onlyMaster = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
-  return res.status(403).json({ message: 'Forbidden' });
-};
+const onlyMaster = require('../middleware/onlyMaster');
 
 router.get('/', auth, characteristicController.getAll);
 router.post('/', auth, onlyMaster, characteristicController.create);

--- a/backend/src/routes/map.js
+++ b/backend/src/routes/map.js
@@ -12,10 +12,7 @@ const storage = multer.diskStorage({
 });
 const upload = multer({ storage });
 
-const onlyMaster = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
-  return res.status(403).json({ message: 'Forbidden' });
-};
+const onlyMaster = require('../middleware/onlyMaster');
 
 router.get('/', auth, mapController.getAll);
 router.post('/', auth, onlyMaster, upload.single('image'), mapController.create);

--- a/backend/src/routes/music.js
+++ b/backend/src/routes/music.js
@@ -3,10 +3,7 @@ const router = express.Router();
 const musicController = require('../controllers/musicController');
 const auth = require('../middleware/authMiddleware');
 
-const onlyMaster = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
-  return res.status(403).json({ message: 'Forbidden' });
-};
+const onlyMaster = require('../middleware/onlyMaster');
 
 router.get('/', auth, musicController.getAll);
 router.post('/', auth, onlyMaster, musicController.create);

--- a/backend/src/routes/profession.js
+++ b/backend/src/routes/profession.js
@@ -3,10 +3,7 @@ const router = express.Router();
 const professionController = require('../controllers/professionController');
 const auth = require('../middleware/authMiddleware');
 
-const onlyMaster = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
-  return res.status(403).json({ message: 'Forbidden' });
-};
+const onlyMaster = require('../middleware/onlyMaster');
 
 router.get('/', auth, professionController.getAll);
 router.post('/', auth, onlyMaster, professionController.create);

--- a/backend/src/routes/race.js
+++ b/backend/src/routes/race.js
@@ -4,10 +4,7 @@ const raceController = require('../controllers/raceController');
 const auth = require('../middleware/authMiddleware');
 
 // Тільки для майстра або адміна
-const onlyMaster = (req, res, next) => {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) return next();
-  return res.status(403).json({ message: 'Forbidden' });
-};
+const onlyMaster = require('../middleware/onlyMaster');
 
 router.get('/', auth, raceController.getAll);
 router.post('/', auth, onlyMaster, raceController.create);


### PR DESCRIPTION
## Summary
- export `onlyMaster` middleware cleanly
- reuse middleware in characteristic, map, music, profession and race routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8371e2548322b5b7687a1551ecd6