### PR TITLE
Enable master role management

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -8,3 +8,21 @@ exports.getUsers = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.updateUserRole = async (req, res) => {
+  try {
+    const { role } = req.body;
+    if (!['player', 'master', 'admin'].includes(role)) {
+      return res.status(400).json({ message: 'Invalid role' });
+    }
+    const user = await User.findByIdAndUpdate(
+      req.params.id,
+      { role },
+      { new: true }
+    ).select('-password');
+    if (!user) return res.status(404).json({ message: 'User not found' });
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -7,7 +7,7 @@ const JWT_SECRET = process.env.JWT_SECRET;
 // Реєстрація
 exports.register = async (req, res) => {
   try {
-    const { login, password, username } = req.body;
+    const { login, password, username, role } = req.body;
     if (!login || !password) {
       return res.status(400).json({ message: "Login and password are required" });
     }
@@ -21,7 +21,12 @@ exports.register = async (req, res) => {
     }
 
     const hash = await bcrypt.hash(password, 10);
-    const user = new User({ login, password: hash, username: finalUsername });
+    const user = new User({
+      login,
+      password: hash,
+      username: finalUsername,
+      role: role === 'master' ? 'master' : 'player',
+    });
     await user.save();
 
     res.status(201).json({

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -3,7 +3,9 @@ const router = express.Router();
 const adminController = require('../controllers/adminController');
 const auth = require('../middleware/authMiddleware');
 const onlyMaster = require('../middleware/onlyMaster');
+const isAdmin = require('../middleware/isAdmin');
 
 router.get('/users', auth, onlyMaster, adminController.getUsers);
+router.put('/users/:id/role', auth, isAdmin, adminController.updateUserRole);
 
 module.exports = router;

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -51,7 +51,7 @@ function init(httpServer) {
             .lean();
         }
       }
-      if (!sess.gm) {
+      if (user.role === 'master' || !sess.gm) {
         sess.gm = user._id;
         socket.emit('gm-assigned');
       }

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -38,7 +38,7 @@ export default function GameTablePage() {
     return () => socket.disconnect();
   }, [tableId, user, characterId]);
 
-  const isGM = gm && user && gm.toString() === user._id;
+  const isGM = (user?.role === 'master') || (gm && user && gm.toString() === user._id);
 
 
   return (

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -15,7 +15,7 @@ export default function LobbyPage() {
   const [tableId, setTableId] = useState(null);
   const [players, setPlayers] = useState([]);
   const [character, setCharacter] = useState(null);
-  const [isGM, setIsGM] = useState(false);
+  const [isGM, setIsGM] = useState(user?.role === 'master');
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -45,6 +45,10 @@ export default function LobbyPage() {
     socket.on('game-started', () => navigate(`/table/${tableId}`));
     return () => socket.disconnect();
   }, [tableId, user, char, navigate]);
+
+  useEffect(() => {
+    if (user?.role === 'master') setIsGM(true);
+  }, [user]);
 
   const startGame = () => {
     if (tableId) socket.emit('start-game', { tableId });

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 function RegisterPage() {
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
+  const [role, setRole] = useState('player');
   const { showToast } = useToast();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -21,6 +22,7 @@ function RegisterPage() {
         login,
         password,
         username: login,
+        role,
       });
 
       const response = await api.post("/auth/login", {
@@ -62,6 +64,14 @@ function RegisterPage() {
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             required
           />
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="p-2 rounded bg-[#3c2a20] text-white"
+          >
+            <option value="player">Гравець</option>
+            <option value="master">Майстер</option>
+          </select>
           <button
             type="submit"
             className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold"


### PR DESCRIPTION
## Summary
- allow specifying `master` role on registration
- add admin endpoint to change user roles
- assign GM based on user role in Socket.IO lobby
- expose master role selection in registration form
- grant GM actions if user role is master

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d838161188322bef9250ea5b7af88