### PR TITLE
Remove redundant token usage

### DIFF
--- a/frontend/src/components/DiceRoller.jsx
+++ b/frontend/src/components/DiceRoller.jsx
@@ -6,7 +6,6 @@ const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
 export default function DiceRoller({ sessionId, isMaster }) {
   const [rolling, setRolling] = useState(false);
   const [lastRoll, setLastRoll] = useState(null);
-  const { token } = useUserStore();
 
   const rollDice = async (diceType, isPrivate = false) => {
     setRolling(true);

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 import api from '../api/axios';
 
 export default function MusicPlayer({ isGM }) {
-  const { token } = useUserStore();
   const [tracks, setTracks] = useState([]);
   const [current, setCurrent] = useState(null);
   const [volume, setVolume] = useState(() => {

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -1,10 +1,7 @@
 import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
-import { useUserStore } from '../../store/user'
-
 export default function AdminCharacteristicsPage() {
-  const { token } = useUserStore();
   const [characteristics, setCharacteristics] = useState([]);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -12,7 +9,7 @@ export default function AdminCharacteristicsPage() {
 
   const fetchCharacteristics = async () => {
     setLoading(true);
-    const res = await api.get('/characteristic', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/characteristic');
     setCharacteristics(res.data);
     setLoading(false);
   };
@@ -20,12 +17,12 @@ export default function AdminCharacteristicsPage() {
 
   const addCharacteristic = async (e) => {
     e.preventDefault();
-    await api.post('/characteristic', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/characteristic', { name, description });
     setName(''); setDescription(''); fetchCharacteristics();
   };
 
   const removeCharacteristic = async (id) => {
-    await api.delete(`/characteristic/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/characteristic/${id}`);
     fetchCharacteristics();
   };
 

--- a/frontend/src/pages/admin/AdminInventoryPage.jsx
+++ b/frontend/src/pages/admin/AdminInventoryPage.jsx
@@ -1,12 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import api from '../../api/axios';
-import { useUserStore } from '../../store/user';
 import InventoryEditor from '../../components/InventoryEditor';
 
 export default function AdminInventoryPage() {
   const { characterId } = useParams();
-  const { token } = useUserStore();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
 
@@ -14,9 +12,7 @@ export default function AdminInventoryPage() {
     const fetchInventory = async () => {
       setLoading(true);
       try {
-        const res = await api.get(`/inventory/${characterId}`, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
+        const res = await api.get(`/inventory/${characterId}`);
         const data = res.data?.items || [];
         setItems(data.map(it => it.name || it.item || it));
       } catch (err) {
@@ -25,13 +21,12 @@ export default function AdminInventoryPage() {
       setLoading(false);
     };
     fetchInventory();
-  }, [characterId, token]);
+  }, [characterId]);
 
   const handleSave = async () => {
     await api.put(
       `/inventory/${characterId}`,
-      { items: items.map(name => ({ name })) },
-      { headers: { Authorization: `Bearer ${token}` } }
+      { items: items.map(name => ({ name })) }
     );
     alert('Збережено');
   };

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -1,10 +1,7 @@
 import api from '../../api/axios';
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom'
-import { useUserStore } from '../../store/user'
-
 export default function AdminMapsPage() {
-  const { token } = useUserStore();
   const [maps, setMaps] = useState([]);
   const [name, setName] = useState('');
   const [file, setFile] = useState(null);
@@ -13,7 +10,7 @@ export default function AdminMapsPage() {
 
   const fetchMaps = async () => {
     setLoading(true);
-    const res = await api.get('/map', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/map');
     setMaps(res.data);
     setLoading(false);
   };
@@ -26,13 +23,13 @@ export default function AdminMapsPage() {
     formData.append('name', name);
     formData.append('image', file);
     await api.post('/map', formData, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' },
+      headers: { 'Content-Type': 'multipart/form-data' },
     });
     setName(''); setFile(null); fileInput.current.value = null; fetchMaps();
   };
 
   const removeMap = async (id) => {
-    await api.delete(`/map/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/map/${id}`);
     fetchMaps();
   };
 

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -1,10 +1,7 @@
 import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
-import { useUserStore } from '../../store/user'
-
 export default function AdminMusicPage() {
-  const { token } = useUserStore();
   const [tracks, setTracks] = useState([]);
   const [title, setTitle] = useState('');
   const [url, setUrl] = useState('');
@@ -12,7 +9,7 @@ export default function AdminMusicPage() {
 
   const fetchTracks = async () => {
     setLoading(true);
-    const res = await api.get('/music', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/music');
     setTracks(res.data);
     setLoading(false);
   };
@@ -21,12 +18,12 @@ export default function AdminMusicPage() {
   const addTrack = async (e) => {
     e.preventDefault();
     if (!title || !url) return;
-    await api.post('/music', { title, url }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/music', { title, url });
     setTitle(''); setUrl(''); fetchTracks();
   };
 
   const removeTrack = async (id) => {
-    await api.delete(`/music/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/music/${id}`);
     fetchTracks();
   };
 

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -1,10 +1,7 @@
 import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
-import { useUserStore } from '../../store/user'
-
 export default function AdminProfessionsPage() {
-  const { token } = useUserStore();
   const [professions, setProfessions] = useState([]);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -12,7 +9,7 @@ export default function AdminProfessionsPage() {
 
   const fetchProfessions = async () => {
     setLoading(true);
-    const res = await api.get('/profession', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/profession');
     setProfessions(res.data);
     setLoading(false);
   };
@@ -20,17 +17,17 @@ export default function AdminProfessionsPage() {
 
   const addProfession = async (e) => {
     e.preventDefault();
-    await api.post('/profession', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/profession', { name, description });
     setName(''); setDescription(''); fetchProfessions();
   };
 
   const removeProfession = async (id) => {
-    await api.delete(`/profession/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/profession/${id}`);
     fetchProfessions();
   };
 
   const saveProfession = async (id, data) => {
-    await api.put(`/profession/${id}`, data, { headers: { Authorization: `Bearer ${token}` } });
+    await api.put(`/profession/${id}`, data);
     fetchProfessions();
   };
 

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -1,10 +1,7 @@
 import api from '../../api/axios';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
-import { useUserStore } from '../../store/user'
-
 export default function AdminRacesPage() {
-  const { token } = useUserStore();
   const [races, setRaces] = useState([]);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -12,7 +9,7 @@ export default function AdminRacesPage() {
 
   const fetchRaces = async () => {
     setLoading(true);
-    const res = await api.get('/race', { headers: { Authorization: `Bearer ${token}` } });
+    const res = await api.get('/race');
     setRaces(res.data);
     setLoading(false);
   };
@@ -20,17 +17,17 @@ export default function AdminRacesPage() {
 
   const addRace = async (e) => {
     e.preventDefault();
-    await api.post('/race', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post('/race', { name, description });
     setName(''); setDescription(''); fetchRaces();
   };
 
   const removeRace = async (id) => {
-    await api.delete(`/race/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    await api.delete(`/race/${id}`);
     fetchRaces();
   };
 
   const saveRace = async (id, raceData) => {
-    await api.put(`/race/${id}`, raceData, { headers: { Authorization: `Bearer ${token}` } });
+    await api.put(`/race/${id}`, raceData);
     fetchRaces();
   };
 


### PR DESCRIPTION
## Summary
- drop unused `token` prop from DiceRoller and MusicPlayer
- remove explicit Authorization headers from admin pages
- rely on axios interceptor for auth header

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d83863fec8322ba75613b725e4d05