### PR TITLE
Fix middleware paths

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const adminController = require('../controllers/adminController');
 
-const auth = require('../middleware/authMiddleware');
-const onlyMaster = require('../middleware/onlyMaster');
-const isAdmin = require('../middleware/isAdmin');
+const auth = require('../middlewares/authMiddleware');
+const onlyMaster = require('../middlewares/onlyMaster');
+const isAdmin = require('../middlewares/isAdmin');
 
 
 router.get('/users', auth, onlyMaster, adminController.getUsers);

--- a/backend/src/routes/characteristic.js
+++ b/backend/src/routes/characteristic.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const characteristicController = require('../controllers/characteristicController');
 const auth = require('../middlewares/authMiddleware');
 
-const onlyMaster = require('../middleware/onlyMaster');
+const onlyMaster = require('../middlewares/onlyMaster');
 
 router.get('/', auth, characteristicController.getAll);
 router.post('/', auth, onlyMaster, characteristicController.create);

--- a/backend/src/routes/map.js
+++ b/backend/src/routes/map.js
@@ -12,7 +12,7 @@ const storage = multer.diskStorage({
 });
 const upload = multer({ storage });
 
-const onlyMaster = require('../middleware/onlyMaster');
+const onlyMaster = require('../middlewares/onlyMaster');
 
 router.get('/', auth, mapController.getAll);
 router.post('/', auth, onlyMaster, upload.single('image'), mapController.create);

--- a/backend/src/routes/music.js
+++ b/backend/src/routes/music.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const musicController = require('../controllers/musicController');
 const auth = require('../middlewares/authMiddleware');
 
-const onlyMaster = require('../middleware/onlyMaster');
+const onlyMaster = require('../middlewares/onlyMaster');
 
 router.get('/', auth, musicController.getAll);
 router.post('/', auth, onlyMaster, musicController.create);

--- a/backend/src/routes/profession.js
+++ b/backend/src/routes/profession.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const professionController = require('../controllers/professionController');
 const auth = require('../middlewares/authMiddleware');
 
-const onlyMaster = require('../middleware/onlyMaster');
+const onlyMaster = require('../middlewares/onlyMaster');
 
 router.get('/', auth, professionController.getAll);
 router.post('/', auth, onlyMaster, professionController.create);

--- a/backend/src/routes/race.js
+++ b/backend/src/routes/race.js
@@ -4,7 +4,7 @@ const raceController = require('../controllers/raceController');
 const auth = require('../middlewares/authMiddleware');
 
 // Тільки для майстра або адміна
-const onlyMaster = require('../middleware/onlyMaster');
+const onlyMaster = require('../middlewares/onlyMaster');
 
 router.get('/', auth, raceController.getAll);
 router.post('/', auth, onlyMaster, raceController.create);


### PR DESCRIPTION
## Summary
- fix imports for admin routes
- point resources routes to `middlewares` directory

## Testing
- `npm --prefix backend test`
- `node backend/src/app.js` *(fails to connect to MongoDB because env vars aren't set, but no missing module errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c0933a0832286757ea2bc90b5ff