### PR TITLE
Add admin user management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import CharacterCreatePage from './pages/CharacterCreatePage';
 import LobbyPage from './pages/LobbyPage';
 import MasterPage from './pages/MasterPage';
 import AdminInventoryPage from './pages/admin/AdminInventoryPage';
+import AdminUsersPage from './pages/admin/AdminUsersPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
 import MasterLoginPage from './pages/MasterLoginPage';
@@ -32,6 +33,7 @@ const App = () => (
     <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
     <Route path="/master" element={isAdmin() ? <MasterPage /> : <Navigate to="/master/login" />} />
     <Route path="/master/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/master/login" />} />
+    <Route path="/master/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/master/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
     <Route path="/table/:tableId" element={<GameTablePage />} />
     <Route path="*" element={<Navigate to="/" />} />

--- a/frontend/src/api/adminActions.js
+++ b/frontend/src/api/adminActions.js
@@ -15,3 +15,8 @@ export const deleteRace = (id) => api.delete(`/race/${id}`);
 
 // Карти
 export const uploadMap = (data) => api.post("/map", data);
+
+// Користувачі
+export const getUsers = () => api.get('/admin/users');
+export const updateUserRole = (id, role) =>
+  api.put(`/admin/users/${id}/role`, { role });

--- a/frontend/src/pages/MasterPage.jsx
+++ b/frontend/src/pages/MasterPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import AdminCard from "../components/AdminCard";
+import { useNavigate } from "react-router-dom";
 import {
   setMusic,
   createRace,
@@ -15,6 +16,7 @@ export default function MasterPage() {
   const [videoId, setVideoId] = useState(null);
   const [races, setRaces] = useState([]);
   const [log, setLog] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     getRaces().then((res) => {
@@ -90,6 +92,7 @@ export default function MasterPage() {
         <AdminCard title="Встановити музику" onClick={handleSetMusic} />
         <AdminCard title="Створити нову расу" onClick={handleCreateRace} />
         <AdminCard title="Завантажити карту" onClick={handleUploadMap} />
+        <AdminCard title="Користувачі" onClick={() => navigate('/master/users')} />
         <AdminCard title="Запустити сесію" onClick={handleStartSession} />
         <AdminCard title="Завершити сесію" onClick={handleEndSession} />
       </div>

--- a/frontend/src/pages/admin/AdminUsersPage.jsx
+++ b/frontend/src/pages/admin/AdminUsersPage.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { getUsers, updateUserRole } from '../../api/adminActions';
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    try {
+      const res = await getUsers();
+      setUsers(res.data);
+    } catch {
+      setUsers([]);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { fetchUsers(); }, []);
+
+  const toggleRole = async (id, role) => {
+    const newRole = role === 'master' ? 'player' : 'master';
+    try {
+      await updateUserRole(id, newRole);
+      setUsers(u => u.map(user => user._id === id ? { ...user, role: newRole } : user));
+    } catch {}
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-dndbg p-4">
+      <div className="bg-[#322018]/90 p-8 rounded-2xl shadow-dnd w-full max-w-xl">
+        <h1 className="font-dnd text-2xl text-dndgold mb-4">Адмін: Користувачі</h1>
+        {loading ? (
+          <div className="text-center text-dndgold">Завантаження...</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-dndgold divide-y divide-dndgold/20">
+              <thead>
+                <tr className="text-left">
+                  <th className="py-2">Логін</th>
+                  <th className="py-2">Ім'я</th>
+                  <th className="py-2">Роль</th>
+                  <th className="py-2 w-24">Дії</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-dndgold/20">
+                {users.map(user => (
+                  <tr key={user._id}>
+                    <td className="py-1 pr-2">{user.login}</td>
+                    <td className="py-1 pr-2">{user.username}</td>
+                    <td className="py-1 pr-2">{user.role}</td>
+                    <td className="py-1">
+                      <button
+                        onClick={() => toggleRole(user._id, user.role)}
+                        className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1"
+                      >
+                        Змінити
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -4,3 +4,4 @@ export { default as AdminCharacteristicsPage } from './AdminCharacteristicsPage'
 export { default as AdminMapsPage } from './AdminMapsPage';
 export { default as AdminMusicPage } from './AdminMusicPage';
 export { default as AdminInventoryPage } from './AdminInventoryPage';
+export { default as AdminUsersPage } from './AdminUsersPage';


### PR DESCRIPTION
## Summary
- list and update users from admin panel
- expose admin API functions for users
- route `/master/users` for admin only access
- link to users management in master page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d9755dedc83228b15c044fbcebaa9