### PR TITLE
Rename master pages to admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project combines an Express/MongoDB backend with a React frontend.
    ```
 
    This script also creates an admin account with login **root** and password
-   **kolokol911**. You must sign in with this account to access `/master`.
+   **kolokol911**. You must sign in with this account to access `/admin`.
 
 ## Running the app
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,12 +5,12 @@ import RegisterPage from './pages/RegisterPage';
 import ProfilePage from './pages/ProfilePage';
 import CharacterCreatePage from './pages/CharacterCreatePage';
 import LobbyPage from './pages/LobbyPage';
-import MasterPage from './pages/MasterPage';
+import AdminPage from './pages/AdminPage';
 import AdminInventoryPage from './pages/admin/AdminInventoryPage';
 import AdminUsersPage from './pages/admin/AdminUsersPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
-import MasterLoginPage from './pages/MasterLoginPage';
+import AdminLoginPage from './pages/AdminLoginPage';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
 const isAdmin = () => {
@@ -26,14 +26,14 @@ const App = () => (
   <Routes>
     <Route path="/" element={<Navigate to={isAuthenticated() ? "/profile" : "/login"} />} />
     <Route path="/login" element={<LoginPage />} />
-    <Route path="/master/login" element={<MasterLoginPage />} />
+    <Route path="/admin/login" element={<AdminLoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
     <Route path="/profile" element={isAuthenticated() ? <ProfilePage /> : <Navigate to="/login" />} />
     <Route path="/create-character" element={isAuthenticated() ? <CharacterCreatePage /> : <Navigate to="/login" />} />
     <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
-    <Route path="/master" element={isAdmin() ? <MasterPage /> : <Navigate to="/master/login" />} />
-    <Route path="/master/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/master/login" />} />
-    <Route path="/master/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/master/login" />} />
+    <Route path="/admin" element={isAdmin() ? <AdminPage /> : <Navigate to="/admin/login" />} />
+    <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />
+    <Route path="/admin/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/admin/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
     <Route path="/table/:tableId" element={<GameTablePage />} />
     <Route path="*" element={<Navigate to="/" />} />

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -5,7 +5,7 @@ import { useUserStore } from '../store/user';
 import { useState } from 'react';
 import api from "../api/axios";
 
-function MasterLoginPage() {
+function AdminLoginPage() {
   const [login, setLogin] = useState('');
   const [password, setPassword] = useState('');
   const { showToast } = useToast();
@@ -25,7 +25,7 @@ function MasterLoginPage() {
     try {
       const res = await api.post('/admin/auth', { login, password });
       setUser(res.data.user, res.data.token);
-      navigate('/master');
+      navigate('/admin');
     } catch (err) {
       setError(err.response?.data?.message || 'Login failed');
     }
@@ -37,7 +37,7 @@ function MasterLoginPage() {
       style={{ backgroundImage: `url('/map-bg.jpg')` }}
     >
       <div className="bg-[#2d1d14]/90 p-8 rounded-lg shadow-lg w-full max-w-md text-center text-white">
-        <h1 className="text-3xl font-dnd mb-4">Master Login</h1>
+        <h1 className="text-3xl font-dnd mb-4">Admin Login</h1>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {error && <div className="text-red-400">{error}</div>}
           <input
@@ -67,4 +67,4 @@ function MasterLoginPage() {
   );
 }
 
-export default MasterLoginPage;
+export default AdminLoginPage;

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -12,7 +12,7 @@ import {
   getSessionLog,
 } from "../api/adminActions";
 
-export default function MasterPage() {
+export default function AdminPage() {
   const [videoId, setVideoId] = useState(null);
   const [races, setRaces] = useState([]);
   const [log, setLog] = useState([]);
@@ -86,13 +86,13 @@ export default function MasterPage() {
       className="min-h-screen bg-cover bg-center p-8 font-dnd text-white"
       style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
-      <h1 className="text-3xl text-dndgold mb-6">Панель Майстра</h1>
+      <h1 className="text-3xl text-dndgold mb-6">Панель Адміністратора</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         <AdminCard title="Встановити музику" onClick={handleSetMusic} />
         <AdminCard title="Створити нову расу" onClick={handleCreateRace} />
         <AdminCard title="Завантажити карту" onClick={handleUploadMap} />
-        <AdminCard title="Користувачі" onClick={() => navigate('/master/users')} />
+        <AdminCard title="Користувачі" onClick={() => navigate('/admin/users')} />
         <AdminCard title="Запустити сесію" onClick={handleStartSession} />
         <AdminCard title="Завершити сесію" onClick={handleEndSession} />
       </div>

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -14,7 +14,7 @@ export default function AdminPanel() {
 
   return (
     <div className="min-h-screen p-6 text-dndgold font-dnd">
-      <h1 className="text-3xl mb-4">Панель Майстра</h1>
+      <h1 className="text-3xl mb-4">Панель Адміністратора</h1>
       <AdminStats data={raceStats} />
       <p>Тут буде можливість редагування рас, класів, інвентарю та характеристик.</p>
     </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -69,7 +69,7 @@ function LoginPage() {
           </button>
         </form>
         <Link
-          to="/master/login"
+          to="/admin/login"
           className="mt-4 inline-block bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold"
         >
           Адмінка

--- a/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
+++ b/frontend/src/pages/admin/AdminCharacteristicsPage.jsx
@@ -59,7 +59,7 @@ export default function AdminCharacteristicsPage() {
             ))}
           </ul>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminInventoryPage.jsx
+++ b/frontend/src/pages/admin/AdminInventoryPage.jsx
@@ -46,7 +46,7 @@ export default function AdminInventoryPage() {
         >
           Зберегти
         </button>
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">
           ← Назад
         </Link>
       </div>

--- a/frontend/src/pages/admin/AdminMapsPage.jsx
+++ b/frontend/src/pages/admin/AdminMapsPage.jsx
@@ -68,7 +68,7 @@ export default function AdminMapsPage() {
             ))}
           </ul>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminMusicPage.jsx
+++ b/frontend/src/pages/admin/AdminMusicPage.jsx
@@ -61,7 +61,7 @@ export default function AdminMusicPage() {
             ))}
           </ul>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -104,7 +104,7 @@ export default function AdminProfessionsPage() {
             </table>
           </div>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -104,7 +104,7 @@ export default function AdminRacesPage() {
             </table>
           </div>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminUsersPage.jsx
+++ b/frontend/src/pages/admin/AdminUsersPage.jsx
@@ -64,7 +64,7 @@ export default function AdminUsersPage() {
             </table>
           </div>
         )}
-        <Link to="/master" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
+        <Link to="/admin" className="block text-dndgold underline mt-6 text-center">← Назад</Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- rename MasterPage → AdminPage
- rename MasterLoginPage → AdminLoginPage
- update routes and links from `/master` to `/admin`
- update page titles to "Панель Адміністратора"
- document new admin path in README

## Testing
- `npm run dev` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684d9bb943d883228a5ee49a670ba92d