### PR TITLE
Add DB-driven inventory generation

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -5,6 +5,8 @@ const Race = require('../src/models/Race');
 const Profession = require('../src/models/Profession');
 const Characteristic = require('../src/models/Characteristic');
 const User = require('../src/models/User');
+const Item = require('../src/models/Item');
+const StartingSet = require('../src/models/StartingSet');
 const bcrypt = require('bcrypt');
 
 const MONGO_URI = process.env.MONGO_URI;
@@ -74,6 +76,112 @@ async function seed() {
     'CHA'
   ];
 
+  const classInventory = {
+    Warrior: {
+      weapon: [
+        { item: 'Меч', bonus: { STR: 2 } },
+        { item: 'Сокира', bonus: { STR: 2 } }
+      ],
+      armor: [
+        { item: 'Щит', bonus: { CON: 1 } },
+        { item: 'Шкіряна броня', bonus: { DEX: 1 } }
+      ],
+      misc: [
+        { item: 'Зілля здоров’я' }
+      ]
+    },
+    Mage: {
+      weapon: [
+        { item: 'Магічний посох', bonus: { INT: 2 } },
+        { item: 'Чарівна паличка', bonus: { INT: 1 } }
+      ],
+      armor: [
+        { item: 'Обруч мудрості', bonus: { INT: 1 } },
+        { item: 'Тканинна мантія', bonus: { CON: 1 } }
+      ],
+      misc: [
+        { item: 'Мана-зілля' },
+        { item: 'Книга заклять' }
+      ]
+    },
+    Rogue: {
+      weapon: [
+        { item: 'Кинджал', bonus: { DEX: 1 } },
+        { item: 'Короткий меч', bonus: { DEX: 1 } }
+      ],
+      armor: [
+        { item: 'Плащ тіні', bonus: { DEX: 1 } },
+        { item: 'Легка броня', bonus: { DEX: 1 } }
+      ],
+      misc: [
+        { item: 'Відмички' }
+      ]
+    },
+    Healer: {
+      weapon: [
+        { item: 'Жезл лікування', bonus: { CHA: 1 } },
+        { item: 'Священний посох', bonus: { CHA: 1 } }
+      ],
+      armor: [
+        { item: 'Легка ряса', bonus: { CON: 1 } },
+        { item: 'Травник' }
+      ],
+      misc: [
+        { item: 'Зілля лікування' }
+      ]
+    },
+    Ranger: {
+      weapon: [
+        { item: 'Лук', bonus: { DEX: 1 } },
+        { item: 'Арбалет', bonus: { DEX: 1 } }
+      ],
+      armor: [
+        { item: 'Шкіряна броня', bonus: { DEX: 1 } },
+        { item: 'Ніж для виживання' }
+      ],
+      misc: [
+        { item: 'Колчан стріл' }
+      ]
+    },
+    Bard: {
+      weapon: [
+        { item: 'Лютня', bonus: { CHA: 1 } },
+        { item: 'Легкий меч', bonus: { DEX: 1 } }
+      ],
+      armor: [
+        { item: 'Короткий лук', bonus: { DEX: 1 } },
+        { item: 'Пісенник' }
+      ],
+      misc: []
+    },
+    Paladin: {
+      weapon: [
+        { item: 'Молот', bonus: { STR: 1 } },
+        { item: 'Святий меч', bonus: { STR: 2 } }
+      ],
+      armor: [
+        { item: 'Латна броня', bonus: { CON: 2 } },
+        { item: 'Святий щит', bonus: { CHA: 1 } }
+      ],
+      misc: [
+        { item: 'Святий амулет' }
+      ]
+    }
+  };
+
+  const raceInventory = {
+    Elf: [{ item: 'Ельфійські стріли', bonus: { DEX: 1 } }],
+    Orc: [{ item: 'Кістяний талісман', bonus: { STR: 1 } }],
+    Human: [{ item: 'Монета удачі', bonus: { CHA: 1 } }],
+    Gnome: [{ item: 'Гвинтовий ключ' }],
+    Dwarf: [{ item: 'Похідна кружка', bonus: { CON: 1 } }],
+    Halfling: [{ item: 'Трубка та тютюн', bonus: { CHA: 1 } }],
+    Demon: [{ item: 'Темний камінь', bonus: { INT: 1 } }],
+    Beastkin: [{ item: 'Кігтістий амулет', bonus: { DEX: 1 } }],
+    Angel: [{ item: 'Пір’я з крила', bonus: { CHA: 1 } }],
+    Lizardman: [{ item: 'Луска пращура', bonus: { CON: 1 } }]
+  };
+
   if (await Race.countDocuments() === 0) {
     await Race.insertMany(races.map(name => ({ name })));
     console.log('Races seeded');
@@ -87,6 +195,62 @@ async function seed() {
   if (await Characteristic.countDocuments() === 0) {
     await Characteristic.insertMany(characteristics.map(name => ({ name })));
     console.log('Characteristics seeded');
+  }
+
+  const addItem = (map, def, type) => {
+    if (!map.has(def.item)) {
+      map.set(def.item, { name: def.item, type, bonuses: def.bonus || {} });
+    }
+  };
+
+  const itemMap = new Map();
+  for (const groups of Object.values(classInventory)) {
+    for (const [type, arr] of Object.entries(groups)) {
+      arr.forEach(def => addItem(itemMap, def, type));
+    }
+  }
+  for (const arr of Object.values(raceInventory)) {
+    arr.forEach(def => addItem(itemMap, def, 'race'));
+  }
+
+  let itemsByName = {};
+  if (await Item.countDocuments() === 0) {
+    const inserted = await Item.insertMany(Array.from(itemMap.values()));
+    inserted.forEach(i => { itemsByName[i.name] = i._id; });
+    console.log('Items seeded');
+  } else {
+    const existing = await Item.find();
+    existing.forEach(i => { itemsByName[i.name] = i._id; });
+  }
+
+  const combine = arrays => {
+    if (!arrays.length) return [[]];
+    const [first, ...rest] = arrays;
+    const combos = combine(rest);
+    const result = [];
+    for (const val of first) {
+      for (const c of combos) {
+        result.push([val, ...c]);
+      }
+    }
+    return result;
+  };
+
+  if (await StartingSet.countDocuments() === 0) {
+    const sets = [];
+    for (const [cls, groups] of Object.entries(classInventory)) {
+      const arrays = Object.values(groups)
+        .filter(a => a.length)
+        .map(a => a.map(d => d.item));
+      const combos = combine(arrays);
+      for (const combo of combos) {
+        sets.push({ className: cls, items: combo.map(name => itemsByName[name]) });
+      }
+    }
+    if (sets.length) {
+      await StartingSet.insertMany(sets);
+      console.log('Starting sets seeded');
+    }
   }
 
   const adminLogin = 'root';

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -51,7 +51,7 @@ exports.create = async (req, res) => {
     // Логіка вибору аватара
     const avatar = uploaded || (image && image.trim() ? image : '');
 
-    const inventory = generateInventory(race[0].name, profession[0].name);
+    const inventory = await generateInventory(race[0].name, profession[0].name);
 
     const newChar = new Character({
       user: req.user.id,

--- a/backend/src/models/Item.js
+++ b/backend/src/models/Item.js
@@ -1,0 +1,11 @@
+// backend/models/Item.js
+const mongoose = require('mongoose');
+
+const itemSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  type: { type: String, default: '' },
+  description: { type: String, default: '' },
+  bonuses: { type: Map, of: Number, default: {} }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Item', itemSchema);

--- a/backend/src/models/StartingSet.js
+++ b/backend/src/models/StartingSet.js
@@ -1,0 +1,9 @@
+// backend/models/StartingSet.js
+const mongoose = require('mongoose');
+
+const startingSetSchema = new mongoose.Schema({
+  className: { type: String, required: true },
+  items: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Item' }]
+}, { timestamps: true });
+
+module.exports = mongoose.model('StartingSet', startingSetSchema);

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,95 +1,5 @@
-const classInventory = {
-  Warrior: {
-    weapon: [
-      { item: 'Меч', amount: 1, bonus: { STR: 2 } },
-      { item: 'Сокира', amount: 1, bonus: { STR: 2 } }
-    ],
-    armor: [
-      { item: 'Щит', amount: 1, bonus: { CON: 1 } },
-      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } }
-    ],
-    misc: [
-      { item: 'Зілля здоров’я', amount: 1 }
-    ]
-  },
-  Mage: {
-    weapon: [
-      { item: 'Магічний посох', amount: 1, bonus: { INT: 2 } },
-      { item: 'Чарівна паличка', amount: 1, bonus: { INT: 1 } }
-    ],
-    armor: [
-      { item: 'Обруч мудрості', amount: 1, bonus: { INT: 1 } },
-      { item: 'Тканинна мантія', amount: 1, bonus: { CON: 1 } }
-    ],
-    misc: [
-      { item: 'Мана-зілля', amount: 1 },
-      { item: 'Книга заклять', amount: 1 }
-    ]
-  },
-  Rogue: {
-    weapon: [
-      { item: 'Кинджал', amount: 1, bonus: { DEX: 1 } },
-      { item: 'Короткий меч', amount: 1, bonus: { DEX: 1 } }
-    ],
-    armor: [
-      { item: 'Плащ тіні', amount: 1, bonus: { DEX: 1 } },
-      { item: 'Легка броня', amount: 1, bonus: { DEX: 1 } }
-    ],
-    misc: [
-      { item: 'Відмички', amount: 1 }
-    ]
-  },
-  Healer: {
-    weapon: [
-      { item: 'Жезл лікування', amount: 1, bonus: { CHA: 1 } },
-      { item: 'Священний посох', amount: 1, bonus: { CHA: 1 } }
-    ],
-    armor: [
-      { item: 'Легка ряса', amount: 1, bonus: { CON: 1 } },
-      { item: 'Травник', amount: 1 }
-    ],
-    misc: [
-      { item: 'Зілля лікування', amount: 1 }
-    ]
-  },
-  Ranger: {
-    weapon: [
-      { item: 'Лук', amount: 1, bonus: { DEX: 1 } },
-      { item: 'Арбалет', amount: 1, bonus: { DEX: 1 } }
-    ],
-    armor: [
-      { item: 'Шкіряна броня', amount: 1, bonus: { DEX: 1 } },
-      { item: 'Ніж для виживання', amount: 1 }
-    ],
-    misc: [
-      { item: 'Колчан стріл', amount: 1 }
-    ]
-  },
-  Bard: {
-    weapon: [
-      { item: 'Лютня', amount: 1, bonus: { CHA: 1 } },
-      { item: 'Легкий меч', amount: 1, bonus: { DEX: 1 } }
-    ],
-    armor: [
-      { item: 'Короткий лук', amount: 1, bonus: { DEX: 1 } },
-      { item: 'Пісенник', amount: 1 }
-    ],
-    misc: []
-  },
-  Paladin: {
-    weapon: [
-      { item: 'Молот', amount: 1, bonus: { STR: 1 } },
-      { item: 'Святий меч', amount: 1, bonus: { STR: 2 } }
-    ],
-    armor: [
-      { item: 'Латна броня', amount: 1, bonus: { CON: 2 } },
-      { item: 'Святий щит', amount: 1, bonus: { CHA: 1 } }
-    ],
-    misc: [
-      { item: 'Святий амулет', amount: 1 }
-    ]
-  }
-};
+
+const StartingSet = require('../models/StartingSet');
 
 const raceInventory = {
   Elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
@@ -108,20 +18,23 @@ function randomItem(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-function generateInventory(race, charClass) {
+async function generateInventory(race, charClass) {
   const result = [];
-  const classItems = classInventory[charClass] || {};
-  for (const category of Object.keys(classItems)) {
-    const options = classItems[category];
-    if (Array.isArray(options) && options.length) {
-      const choice = randomItem(options);
-      result.push({ item: choice.item, amount: choice.amount ?? 1, bonus: choice.bonus || {} });
+
+  const sets = await StartingSet.find({ className: charClass }).populate('items');
+  if (sets.length) {
+    const selected = randomItem(sets);
+    for (const item of selected.items) {
+      const bonuses = item.bonuses ? Object.fromEntries(item.bonuses) : {};
+      result.push({ item: item.name, amount: 1, bonus: bonuses });
     }
   }
+
   const raceItems = raceInventory[race] || [];
   for (const r of raceItems) {
     result.push({ item: r.item, amount: r.amount ?? 1, bonus: r.bonus || {} });
   }
+
   return result;
 }
 

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -2,15 +2,18 @@ const characterController = require('../src/controllers/characterController');
 const Race = require('../src/models/Race');
 const Profession = require('../src/models/Profession');
 const Character = require('../src/models/Character');
+const StartingSet = require('../src/models/StartingSet');
 
 jest.mock('../src/models/Race');
 jest.mock('../src/models/Profession');
 jest.mock('../src/models/Character');
+jest.mock('../src/models/StartingSet');
 
 describe('Character Controller - create', () => {
   it('applies race bonuses and class minimums', async () => {
     Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
     Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;
     Character.mockImplementation(data => {
@@ -38,6 +41,7 @@ describe('Character Controller - create', () => {
     Race.find.mockReturnValue({ limit: jest.fn().mockResolvedValue([]) });
     Profession.aggregate.mockResolvedValue([]);
     Profession.find.mockReturnValue({ limit: jest.fn().mockResolvedValue([]) });
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
 
     const req = { user: { id: 'u1' }, body: { name: 'Hero', description: '', image: '' } };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -53,6 +57,7 @@ describe('Character Controller - create', () => {
   it('uses uploaded avatar when file provided', async () => {
     Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
     Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;
     Character.mockImplementation(data => {

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,14 +1,21 @@
+const StartingSet = require('../src/models/StartingSet');
+jest.mock('../src/models/StartingSet');
+
 const generateInventory = require('../src/utils/generateInventory');
 
 describe('generateInventory', () => {
-  it('selects random items for each category', () => {
-    jest
-      .spyOn(Math, 'random')
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(0.9)
-      .mockReturnValueOnce(0);
+  const sets = [
+    { items: [ { name: 'Меч' }, { name: 'Щит' }, { name: 'Зілля здоров’я' } ] },
+    { items: [ { name: 'Меч' }, { name: 'Шкіряна броня' }, { name: 'Зілля здоров’я' } ] },
+    { items: [ { name: 'Сокира' }, { name: 'Щит' }, { name: 'Зілля здоров’я' } ] },
+    { items: [ { name: 'Сокира' }, { name: 'Шкіряна броня' }, { name: 'Зілля здоров’я' } ] },
+  ];
 
-    const items = generateInventory('Orc', 'Warrior');
+  it('selects random items for each category', async () => {
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
+
+    const items = await generateInventory('Orc', 'Warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);
@@ -20,14 +27,11 @@ describe('generateInventory', () => {
     ]);
   });
 
-  it('mixes items across sets', () => {
-    jest
-      .spyOn(Math, 'random')
-      .mockReturnValueOnce(0.9)
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(0);
+  it('mixes items across sets', async () => {
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
-    const items = generateInventory('Orc', 'Warrior');
+    const items = await generateInventory('Orc', 'Warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);
@@ -39,8 +43,9 @@ describe('generateInventory', () => {
     ]);
   });
 
-  it('returns empty array for unknown inputs', () => {
-    const items = generateInventory('Unknown', 'Unknown');
+  it('returns empty array for unknown inputs', async () => {
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+    const items = await generateInventory('Unknown', 'Unknown');
     expect(items).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add `Item` and `StartingSet` mongoose models
- seed new collections and compute class-based starting sets
- load inventory sets from DB instead of hard-coding
- update character creation and associated tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684db0222a188322b18e961b692732d9