### PR TITLE
Add ping route and loading states

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -53,6 +53,8 @@ app.use('/api/session', require('./routes/session'));
 app.use('/api/user', require('./routes/user'));
 
 app.use('/api/ai', require('./routes/ai'));
+// Simple ping route used to wake the server
+app.use('/api/ping', require('./routes/ping'));
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;

--- a/backend/src/routes/ping.js
+++ b/backend/src/routes/ping.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.status(200).json({ message: 'pong' });
+});
+
+module.exports = router;

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useToast } from '../context/ToastContext';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '../store/user';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import api from "../api/axios";
 
 function AdminLoginPage() {
@@ -12,7 +12,12 @@ function AdminLoginPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const setUser = useUserStore((s) => s.setUser);
+
+  useEffect(() => {
+    api.get('/ping').catch(() => {});
+  }, []);
 
   const handleSubmit = async (e) => {
     setError(null);
@@ -22,12 +27,15 @@ function AdminLoginPage() {
     }
     e.preventDefault();
     setError('');
+    setLoading(true);
     try {
       const res = await api.post('/admin/auth', { login, password });
       setUser(res.data.user, res.data.token);
       navigate('/admin');
     } catch (err) {
       setError(err.response?.data?.message || 'Login failed');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -57,9 +65,10 @@ function AdminLoginPage() {
           />
           <button
             type="submit"
-            className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95"
+            disabled={loading}
+            className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95 disabled:opacity-50"
           >
-            {t('login')}
+            {loading ? 'Вхід...' : t('login')}
           </button>
         </form>
       </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -5,7 +5,7 @@ import { useToast } from '../context/ToastContext';
 import { useSettings } from '../context/SettingsContext';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '../store/user';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import api from "../api/axios";
 
 function LoginPage() {
@@ -16,7 +16,13 @@ function LoginPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
   const setUser = useUserStore((s) => s.setUser);
+
+  useEffect(() => {
+    // Wake the backend in case it was idle
+    api.get("/ping").catch(() => {});
+  }, []);
 
   const handleSubmit = async (e) => {
     setError(null);
@@ -26,12 +32,15 @@ function LoginPage() {
     }
     e.preventDefault();
     setError("");
+    setLoading(true);
     try {
       const res = await api.post("/auth/login", { login, password });
       setUser(res.data.user, res.data.token);
       navigate("/profile");
     } catch (err) {
       setError(err.response?.data?.message || "Login failed");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -63,9 +72,10 @@ function LoginPage() {
           />
           <button
             type="submit"
-            className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95"
+            disabled={loading}
+            className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95 disabled:opacity-50"
           >
-            Увійти
+            {loading ? 'Вхід...' : 'Увійти'}
           </button>
         </form>
         <div className="mt-4 flex justify-center gap-4">


### PR DESCRIPTION
## Summary
- add simple `/api/ping` endpoint
- hook new ping route into the Express app
- wake backend from login pages
- add loading states and disable buttons while logging in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684db34b2e8c832282b33fcc5276595e