### PR TITLE
Implement edit mode for admin race/profession tables

### DIFF
--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -6,6 +6,9 @@ export default function AdminProfessionsPage() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
 
   const fetchProfessions = async () => {
     setLoading(true);
@@ -31,8 +34,21 @@ export default function AdminProfessionsPage() {
     fetchProfessions();
   };
 
-  const handleProfessionChange = (id, field, value) => {
-    setProfessions(profs => profs.map(p => p._id === id ? { ...p, [field]: value } : p));
+  const startEdit = (prof) => {
+    setEditingId(prof._id);
+    setEditName(prof.name);
+    setEditDescription(prof.description || '');
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditName('');
+    setEditDescription('');
+  };
+
+  const saveEdit = async (id) => {
+    await saveProfession(id, { name: editName, description: editDescription });
+    cancelEdit();
   };
 
   return (
@@ -71,32 +87,59 @@ export default function AdminProfessionsPage() {
                 {professions.map(p => (
                   <tr key={p._id} className="align-top">
                     <td className="py-1 pr-2">
-                      <input
-                        className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
-                        value={p.name}
-                        onChange={e => handleProfessionChange(p._id, 'name', e.target.value)}
-                      />
+                      {editingId === p._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editName}
+                          onChange={e => setEditName(e.target.value)}
+                        />
+                      ) : (
+                        <span>{p.name}</span>
+                      )}
                     </td>
                     <td className="py-1 pr-2">
-                      <input
-                        className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
-                        value={p.description || ''}
-                        onChange={e => handleProfessionChange(p._id, 'description', e.target.value)}
-                      />
+                      {editingId === p._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editDescription}
+                          onChange={e => setEditDescription(e.target.value)}
+                        />
+                      ) : (
+                        <span>{p.description}</span>
+                      )}
                     </td>
                     <td className="py-1 flex gap-2">
-                      <button
-                        onClick={() => saveProfession(p._id, { name: p.name, description: p.description })}
-                        className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
-                      >
-                        Зберегти
-                      </button>
-                      <button
-                        onClick={() => removeProfession(p._id)}
-                        className="text-dndred hover:underline"
-                      >
-                        Видалити
-                      </button>
+                      {editingId === p._id ? (
+                        <>
+                          <button
+                            onClick={() => saveEdit(p._id)}
+                            className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
+                          >
+                            Зберегти
+                          </button>
+                          <button
+                            onClick={cancelEdit}
+                            className="text-dndred hover:underline"
+                          >
+                            Скасувати
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => startEdit(p)}
+                            className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
+                          >
+                            Редагувати
+                          </button>
+                          <button
+                            onClick={() => removeProfession(p._id)}
+                            className="text-dndred hover:underline"
+                          >
+                            Видалити
+                          </button>
+                        </>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -6,6 +6,9 @@ export default function AdminRacesPage() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
 
   const fetchRaces = async () => {
     setLoading(true);
@@ -31,9 +34,23 @@ export default function AdminRacesPage() {
     fetchRaces();
   };
 
-  const handleRaceChange = (id, field, value) => {
-    setRaces(races => races.map(r => r._id === id ? { ...r, [field]: value } : r));
+  const startEdit = (race) => {
+    setEditingId(race._id);
+    setEditName(race.name);
+    setEditDescription(race.description || '');
   };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditName('');
+    setEditDescription('');
+  };
+
+  const saveEdit = async (id) => {
+    await saveRace(id, { name: editName, description: editDescription });
+    cancelEdit();
+  };
+
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-dndbg p-4">
@@ -71,32 +88,59 @@ export default function AdminRacesPage() {
                 {races.map(race => (
                   <tr key={race._id} className="align-top">
                     <td className="py-1 pr-2">
-                      <input
-                        className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
-                        value={race.name}
-                        onChange={e => handleRaceChange(race._id, 'name', e.target.value)}
-                      />
+                      {editingId === race._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editName}
+                          onChange={e => setEditName(e.target.value)}
+                        />
+                      ) : (
+                        <span>{race.name}</span>
+                      )}
                     </td>
                     <td className="py-1 pr-2">
-                      <input
-                        className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
-                        value={race.description || ''}
-                        onChange={e => handleRaceChange(race._id, 'description', e.target.value)}
-                      />
+                      {editingId === race._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editDescription}
+                          onChange={e => setEditDescription(e.target.value)}
+                        />
+                      ) : (
+                        <span>{race.description}</span>
+                      )}
                     </td>
                     <td className="py-1 flex gap-2">
-                      <button
-                        onClick={() => saveRace(race._id, { name: race.name, description: race.description })}
-                        className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
-                      >
-                        Зберегти
-                      </button>
-                      <button
-                        onClick={() => removeRace(race._id)}
-                        className="text-dndred hover:underline"
-                      >
-                        Видалити
-                      </button>
+                      {editingId === race._id ? (
+                        <>
+                          <button
+                            onClick={() => saveEdit(race._id)}
+                            className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
+                          >
+                            Зберегти
+                          </button>
+                          <button
+                            onClick={cancelEdit}
+                            className="text-dndred hover:underline"
+                          >
+                            Скасувати
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => startEdit(race)}
+                            className="bg-dndgold text-dndred font-dnd rounded-2xl px-2 py-1 transition active:scale-95"
+                          >
+                            Редагувати
+                          </button>
+                          <button
+                            onClick={() => removeRace(race._id)}
+                            className="text-dndred hover:underline"
+                          >
+                            Видалити
+                          </button>
+                        </>
+                      )}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- add editingId and editing state to admin race/profession pages
- allow editing of a single row at a time with save/cancel actions
- keep add/remove behaviour intact

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db5f8e8c48322a3ef2f9a1dd326ac