### PR TITLE
Add code-based lookup for races and classes

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -48,25 +48,25 @@ async function seed() {
   // const characteristics = ['HP', 'MP', 'Strength', 'Agility', 'Intellect'];
 
   const races = [
-    'Human',
-    'Elf',
-    'Orc',
-    'Gnome',
-    'Dwarf',
-    'Halfling',
-    'Demon',
-    'Beastkin',
-    'Angel',
-    'Lizardman'
+    { code: 'human', name: 'Людина' },
+    { code: 'elf', name: 'Ельф' },
+    { code: 'orc', name: 'Орк' },
+    { code: 'gnome', name: 'Гном' },
+    { code: 'dwarf', name: 'Дварф' },
+    { code: 'halfling', name: 'Напіврослик' },
+    { code: 'demon', name: 'Демон' },
+    { code: 'beastkin', name: 'Звіролюд' },
+    { code: 'angel', name: 'Ангел' },
+    { code: 'lizardman', name: 'Ящіролюд' }
   ];
   const professions = [
-    'Warrior',
-    'Mage',
-    'Rogue',
-    'Healer',
-    'Ranger',
-    'Bard',
-    'Paladin'
+    { code: 'warrior', name: 'Воїн' },
+    { code: 'mage', name: 'Маг' },
+    { code: 'rogue', name: 'Шахрай' },
+    { code: 'healer', name: 'Цілитель' },
+    { code: 'ranger', name: 'Рейнджер' },
+    { code: 'bard', name: 'Бард' },
+    { code: 'paladin', name: 'Паладин' }
   ];
   const characteristics = [
     'STR',
@@ -170,25 +170,25 @@ async function seed() {
   };
 
   const raceInventory = {
-    Elf: [{ item: 'Ельфійські стріли', bonus: { DEX: 1 } }],
-    Orc: [{ item: 'Кістяний талісман', bonus: { STR: 1 } }],
-    Human: [{ item: 'Монета удачі', bonus: { CHA: 1 } }],
-    Gnome: [{ item: 'Гвинтовий ключ' }],
-    Dwarf: [{ item: 'Похідна кружка', bonus: { CON: 1 } }],
-    Halfling: [{ item: 'Трубка та тютюн', bonus: { CHA: 1 } }],
-    Demon: [{ item: 'Темний камінь', bonus: { INT: 1 } }],
-    Beastkin: [{ item: 'Кігтістий амулет', bonus: { DEX: 1 } }],
-    Angel: [{ item: 'Пір’я з крила', bonus: { CHA: 1 } }],
-    Lizardman: [{ item: 'Луска пращура', bonus: { CON: 1 } }]
+    elf: [{ item: 'Ельфійські стріли', bonus: { DEX: 1 } }],
+    orc: [{ item: 'Кістяний талісман', bonus: { STR: 1 } }],
+    human: [{ item: 'Монета удачі', bonus: { CHA: 1 } }],
+    gnome: [{ item: 'Гвинтовий ключ' }],
+    dwarf: [{ item: 'Похідна кружка', bonus: { CON: 1 } }],
+    halfling: [{ item: 'Трубка та тютюн', bonus: { CHA: 1 } }],
+    demon: [{ item: 'Темний камінь', bonus: { INT: 1 } }],
+    beastkin: [{ item: 'Кігтістий амулет', bonus: { DEX: 1 } }],
+    angel: [{ item: 'Пір’я з крила', bonus: { CHA: 1 } }],
+    lizardman: [{ item: 'Луска пращура', bonus: { CON: 1 } }]
   };
 
   if (await Race.countDocuments() === 0) {
-    await Race.insertMany(races.map(name => ({ name })));
+    await Race.insertMany(races);
     console.log('Races seeded');
   }
 
   if (await Profession.countDocuments() === 0) {
-    await Profession.insertMany(professions.map(name => ({ name })));
+    await Profession.insertMany(professions);
     console.log('Professions seeded');
   }
 
@@ -244,7 +244,7 @@ async function seed() {
         .map(a => a.map(d => d.item));
       const combos = combine(arrays);
       for (const combo of combos) {
-        sets.push({ className: cls, items: combo.map(name => itemsByName[name]) });
+        sets.push({ classCode: cls.toLowerCase(), items: combo.map(name => itemsByName[name]) });
       }
     }
     if (sets.length) {

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -45,13 +45,19 @@ exports.create = async (req, res) => {
 
 
 
-  const stats = generateStats(race[0].name, profession[0].name);
+  const stats = generateStats(
+    (race[0].code || race[0].name)?.toLowerCase(),
+    (profession[0].code || profession[0].name)?.toLowerCase()
+  );
  
 
     // Логіка вибору аватара
     const avatar = uploaded || (image && image.trim() ? image : '');
 
-    const inventory = await generateInventory(race[0].name, profession[0].name);
+    const inventory = await generateInventory(
+      (race[0].code || race[0].name)?.toLowerCase(),
+      (profession[0].code || profession[0].name)?.toLowerCase()
+    );
 
     const newChar = new Character({
       user: req.user.id,

--- a/backend/src/models/Profession.js
+++ b/backend/src/models/Profession.js
@@ -2,6 +2,7 @@
 const mongoose = require('mongoose');
 
 const professionSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true },
   name: { type: String, required: true, unique: true },
   description: { type: String, default: '' },
 }, { timestamps: true });

--- a/backend/src/models/Race.js
+++ b/backend/src/models/Race.js
@@ -2,6 +2,7 @@
 const mongoose = require('mongoose');
 
 const raceSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true },
   name: { type: String, required: true, unique: true },
   description: { type: String, default: '' },
 }, { timestamps: true });

--- a/backend/src/models/StartingSet.js
+++ b/backend/src/models/StartingSet.js
@@ -2,7 +2,7 @@
 const mongoose = require('mongoose');
 
 const startingSetSchema = new mongoose.Schema({
-  className: { type: String, required: true },
+  classCode: { type: String, required: true },
   items: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Item' }]
 }, { timestamps: true });
 

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -2,26 +2,26 @@
 const StartingSet = require('../models/StartingSet');
 
 const raceInventory = {
-  Elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
-  Orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
-  Human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
-  Gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
-  Dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
-  Halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
-  Demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
-  Beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
-  Angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
-  Lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }]
+  elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
+  orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
+  human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
+  gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
+  dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
+  halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
+  demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
+  beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
+  angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
+  lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }]
 };
 
 function randomItem(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-async function generateInventory(race, charClass) {
+async function generateInventory(raceCode, classCode) {
   const result = [];
 
-  const sets = await StartingSet.find({ className: charClass }).populate('items');
+  const sets = await StartingSet.find({ classCode }).populate('items');
   if (sets.length) {
     const selected = randomItem(sets);
     for (const item of selected.items) {
@@ -30,7 +30,7 @@ async function generateInventory(race, charClass) {
     }
   }
 
-  const raceItems = raceInventory[race] || [];
+  const raceItems = raceInventory[raceCode] || [];
   for (const r of raceItems) {
     result.push({ item: r.item, amount: r.amount ?? 1, bonus: r.bonus || {} });
   }

--- a/backend/src/utils/generateStats.js
+++ b/backend/src/utils/generateStats.js
@@ -7,26 +7,26 @@ const baseStats = {
 };
 
 const raceBonuses = {
-  Human:     { STR: 1, DEX: 1, INT: 1, CON: 1, CHA: 1 },
-  Elf:       { DEX: 2, INT: 1 },
-  Orc:       { STR: 2, CON: 1 },
-  Gnome:     { CON: 2, INT: 1 },
-  Dwarf:     { STR: 2, CHA: 1 },
-  Halfling:  { DEX: 2, CHA: 1 },
-  Demon:     { INT: 2, CHA: 1 },
-  Beastkin:  { DEX: 2, CON: 1 },
-  Angel:     { CHA: 2, INT: 1 },
-  Lizardman: { STR: 2, CON: 1 },
+  human:     { STR: 1, DEX: 1, INT: 1, CON: 1, CHA: 1 },
+  elf:       { DEX: 2, INT: 1 },
+  orc:       { STR: 2, CON: 1 },
+  gnome:     { CON: 2, INT: 1 },
+  dwarf:     { STR: 2, CHA: 1 },
+  halfling:  { DEX: 2, CHA: 1 },
+  demon:     { INT: 2, CHA: 1 },
+  beastkin:  { DEX: 2, CON: 1 },
+  angel:     { CHA: 2, INT: 1 },
+  lizardman: { STR: 2, CON: 1 },
 };
 
 const classMinimums = {
-  Warrior: { STR: 13, CON: 12 },
-  Mage: { INT: 13, CHA: 11 },
-  Rogue: { DEX: 13, INT: 11 },
-  Healer: { CHA: 13, CON: 11 },
-  Ranger: { DEX: 12, STR: 12 },
-  Bard: { CHA: 13, DEX: 12 },
-  Paladin: { STR: 13, CHA: 13 },
+  warrior: { STR: 13, CON: 12 },
+  mage: { INT: 13, CHA: 11 },
+  rogue: { DEX: 13, INT: 11 },
+  healer: { CHA: 13, CON: 11 },
+  ranger: { DEX: 12, STR: 12 },
+  bard: { CHA: 13, DEX: 12 },
+  paladin: { STR: 13, CHA: 13 },
 };
 
 function generateStats(race, charClass) {

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -11,8 +11,8 @@ jest.mock('../src/models/StartingSet');
 
 describe('Character Controller - create', () => {
   it('applies race bonuses and class minimums', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Ельф', code: 'elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Маг', code: 'mage' }]);
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;
@@ -55,8 +55,8 @@ describe('Character Controller - create', () => {
   });
 
   it('uses uploaded avatar when file provided', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Ельф', code: 'elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Маг', code: 'mage' }]);
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -15,7 +15,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
 
-    const items = await generateInventory('Orc', 'Warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);
@@ -31,7 +31,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
-    const items = await generateInventory('Orc', 'Warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);


### PR DESCRIPTION
## Summary
- extend `Race` and `Profession` schemas with a `code` field
- seed Ukrainian names with English codes
- store classCode in `StartingSet`
- update inventory generation to accept codes
- adjust character creation logic
- update unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684db5ebeb0c8322ad1d3ddbf8edb2ef