### PR TITLE
Add code slugs for races and professions

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -9,6 +9,8 @@ const Item = require('../src/models/Item');
 const StartingSet = require('../src/models/StartingSet');
 const bcrypt = require('bcrypt');
 
+const slug = str => str.toLowerCase().replace(/\s+/g, '_');
+
 const MONGO_URI = process.env.MONGO_URI;
 
 if (!MONGO_URI) {
@@ -77,7 +79,7 @@ async function seed() {
   ];
 
   const classInventory = {
-    Warrior: {
+    warrior: {
       weapon: [
         { item: 'Меч', bonus: { STR: 2 } },
         { item: 'Сокира', bonus: { STR: 2 } }
@@ -90,7 +92,7 @@ async function seed() {
         { item: 'Зілля здоров’я' }
       ]
     },
-    Mage: {
+    mage: {
       weapon: [
         { item: 'Магічний посох', bonus: { INT: 2 } },
         { item: 'Чарівна паличка', bonus: { INT: 1 } }
@@ -104,7 +106,7 @@ async function seed() {
         { item: 'Книга заклять' }
       ]
     },
-    Rogue: {
+    rogue: {
       weapon: [
         { item: 'Кинджал', bonus: { DEX: 1 } },
         { item: 'Короткий меч', bonus: { DEX: 1 } }
@@ -117,7 +119,7 @@ async function seed() {
         { item: 'Відмички' }
       ]
     },
-    Healer: {
+    healer: {
       weapon: [
         { item: 'Жезл лікування', bonus: { CHA: 1 } },
         { item: 'Священний посох', bonus: { CHA: 1 } }
@@ -130,7 +132,7 @@ async function seed() {
         { item: 'Зілля лікування' }
       ]
     },
-    Ranger: {
+    ranger: {
       weapon: [
         { item: 'Лук', bonus: { DEX: 1 } },
         { item: 'Арбалет', bonus: { DEX: 1 } }
@@ -143,7 +145,7 @@ async function seed() {
         { item: 'Колчан стріл' }
       ]
     },
-    Bard: {
+    bard: {
       weapon: [
         { item: 'Лютня', bonus: { CHA: 1 } },
         { item: 'Легкий меч', bonus: { DEX: 1 } }
@@ -154,7 +156,7 @@ async function seed() {
       ],
       misc: []
     },
-    Paladin: {
+    paladin: {
       weapon: [
         { item: 'Молот', bonus: { STR: 1 } },
         { item: 'Святий меч', bonus: { STR: 2 } }
@@ -170,25 +172,25 @@ async function seed() {
   };
 
   const raceInventory = {
-    Elf: [{ item: 'Ельфійські стріли', bonus: { DEX: 1 } }],
-    Orc: [{ item: 'Кістяний талісман', bonus: { STR: 1 } }],
-    Human: [{ item: 'Монета удачі', bonus: { CHA: 1 } }],
-    Gnome: [{ item: 'Гвинтовий ключ' }],
-    Dwarf: [{ item: 'Похідна кружка', bonus: { CON: 1 } }],
-    Halfling: [{ item: 'Трубка та тютюн', bonus: { CHA: 1 } }],
-    Demon: [{ item: 'Темний камінь', bonus: { INT: 1 } }],
-    Beastkin: [{ item: 'Кігтістий амулет', bonus: { DEX: 1 } }],
-    Angel: [{ item: 'Пір’я з крила', bonus: { CHA: 1 } }],
-    Lizardman: [{ item: 'Луска пращура', bonus: { CON: 1 } }]
+    elf: [{ item: 'Ельфійські стріли', bonus: { DEX: 1 } }],
+    orc: [{ item: 'Кістяний талісман', bonus: { STR: 1 } }],
+    human: [{ item: 'Монета удачі', bonus: { CHA: 1 } }],
+    gnome: [{ item: 'Гвинтовий ключ' }],
+    dwarf: [{ item: 'Похідна кружка', bonus: { CON: 1 } }],
+    halfling: [{ item: 'Трубка та тютюн', bonus: { CHA: 1 } }],
+    demon: [{ item: 'Темний камінь', bonus: { INT: 1 } }],
+    beastkin: [{ item: 'Кігтістий амулет', bonus: { DEX: 1 } }],
+    angel: [{ item: 'Пір’я з крила', bonus: { CHA: 1 } }],
+    lizardman: [{ item: 'Луска пращура', bonus: { CON: 1 } }]
   };
 
   if (await Race.countDocuments() === 0) {
-    await Race.insertMany(races.map(name => ({ name })));
+    await Race.insertMany(races.map(name => ({ name, code: slug(name) })));
     console.log('Races seeded');
   }
 
   if (await Profession.countDocuments() === 0) {
-    await Profession.insertMany(professions.map(name => ({ name })));
+    await Profession.insertMany(professions.map(name => ({ name, code: slug(name) })));
     console.log('Professions seeded');
   }
 

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -51,7 +51,7 @@ exports.create = async (req, res) => {
     // Логіка вибору аватара
     const avatar = uploaded || (image && image.trim() ? image : '');
 
-    const inventory = await generateInventory(race[0].name, profession[0].name);
+    const inventory = await generateInventory(race[0].code, profession[0].code);
 
     const newChar = new Character({
       user: req.user.id,

--- a/backend/src/controllers/professionController.js
+++ b/backend/src/controllers/professionController.js
@@ -11,8 +11,8 @@ exports.getAll = async (req, res) => {
 
 exports.create = async (req, res) => {
   try {
-    const { name, description } = req.body;
-    const profession = new Profession({ name, description });
+    const { name, code, description } = req.body;
+    const profession = new Profession({ name, code, description });
     await profession.save();
     res.status(201).json(profession);
   } catch (err) {
@@ -22,10 +22,10 @@ exports.create = async (req, res) => {
 
 exports.update = async (req, res) => {
   try {
-    const { name, description } = req.body;
+    const { name, code, description } = req.body;
     const profession = await Profession.findByIdAndUpdate(
       req.params.id,
-      { $set: { name, description } },
+      { $set: { name, code, description } },
       { new: true }
     );
     if (!profession) return res.status(404).json({ message: 'Not found' });

--- a/backend/src/controllers/raceController.js
+++ b/backend/src/controllers/raceController.js
@@ -11,8 +11,8 @@ exports.getAll = async (req, res) => {
 
 exports.create = async (req, res) => {
   try {
-    const { name, description } = req.body;
-    const race = new Race({ name, description });
+    const { name, code, description } = req.body;
+    const race = new Race({ name, code, description });
     await race.save();
     res.status(201).json(race);
   } catch (err) {
@@ -22,10 +22,10 @@ exports.create = async (req, res) => {
 
 exports.update = async (req, res) => {
   try {
-    const { name, description } = req.body;
+    const { name, code, description } = req.body;
     const race = await Race.findByIdAndUpdate(
       req.params.id,
-      { $set: { name, description } },
+      { $set: { name, code, description } },
       { new: true }
     );
     if (!race) return res.status(404).json({ message: 'Not found' });

--- a/backend/src/models/Profession.js
+++ b/backend/src/models/Profession.js
@@ -2,7 +2,8 @@
 const mongoose = require('mongoose');
 
 const professionSchema = new mongoose.Schema({
-  name: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  code: { type: String, required: true, unique: true },
   description: { type: String, default: '' },
 }, { timestamps: true });
 

--- a/backend/src/models/Race.js
+++ b/backend/src/models/Race.js
@@ -2,7 +2,8 @@
 const mongoose = require('mongoose');
 
 const raceSchema = new mongoose.Schema({
-  name: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  code: { type: String, required: true, unique: true },
   description: { type: String, default: '' },
 }, { timestamps: true });
 

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -2,16 +2,16 @@
 const StartingSet = require('../models/StartingSet');
 
 const raceInventory = {
-  Elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
-  Orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
-  Human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
-  Gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
-  Dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
-  Halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
-  Demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
-  Beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
-  Angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
-  Lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }]
+  elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { DEX: 1 } }],
+  orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }],
+  human: [{ item: 'Монета удачі', amount: 1, bonus: { CHA: 1 } }],
+  gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
+  dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { CON: 1 } }],
+  halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { CHA: 1 } }],
+  demon: [{ item: 'Темний камінь', amount: 1, bonus: { INT: 1 } }],
+  beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { DEX: 1 } }],
+  angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { CHA: 1 } }],
+  lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { CON: 1 } }]
 };
 
 function randomItem(list) {

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -11,8 +11,8 @@ jest.mock('../src/models/StartingSet');
 
 describe('Character Controller - create', () => {
   it('applies race bonuses and class minimums', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;
@@ -55,8 +55,8 @@ describe('Character Controller - create', () => {
   });
 
   it('uses uploaded avatar when file provided', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
     let saved;

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -15,7 +15,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
 
-    const items = await generateInventory('Orc', 'Warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);
@@ -31,7 +31,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
-    const items = await generateInventory('Orc', 'Warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     const names = items.map(i => i.item);
@@ -45,7 +45,7 @@ describe('generateInventory', () => {
 
   it('returns empty array for unknown inputs', async () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
-    const items = await generateInventory('Unknown', 'Unknown');
+    const items = await generateInventory('unknown', 'unknown');
     expect(items).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- allow storing a unique slug on races and professions
- seed DB with slugged values
- use codes when generating inventory
- adjust controllers and tests for new field

## Testing
- `npm install --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684db7289c808322b0e82d983b4b45ec