### PR TITLE
Remove role selector from registration

### DIFF
--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next'
 function RegisterPage() {
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
-  const [role, setRole] = useState('player');
   const { showToast } = useToast();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -22,7 +21,7 @@ function RegisterPage() {
         login,
         password,
         username: login,
-        role,
+        role: 'player',
       });
 
       const response = await api.post("/auth/login", {
@@ -64,14 +63,6 @@ function RegisterPage() {
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             required
           />
-          <select
-            value={role}
-            onChange={(e) => setRole(e.target.value)}
-            className="p-2 rounded bg-[#3c2a20] text-white"
-          >
-            <option value="player">Гравець</option>
-            <option value="master">Майстер</option>
-          </select>
           <button
             type="submit"
             className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold"


### PR DESCRIPTION
## Summary
- simplify registration by using a fixed `player` role

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dc6233c848322b1701380b8718daa