### PR TITLE
Support shared lobby IDs and game start tests

### DIFF
--- a/MANUAL_QA.md
+++ b/MANUAL_QA.md
@@ -1,0 +1,16 @@
+# Manual QA Instructions for Lobby to Table Flow
+
+1. Start the backend and frontend servers:
+   ```bash
+   cd backend && npm run dev
+   ```
+   In a new terminal:
+   ```bash
+   cd frontend && npm run dev
+   ```
+
+2. Open the frontend in two separate browser windows.
+3. In the first window navigate to `/lobby`. A table code will appear in the UI and in the URL as `?table=CODE`.
+4. Copy the full URL from the first window and open it in the second window to join the same lobby.
+5. In the first window (the game master), click **"Розпочати гру!"**.
+6. Verify that *both* windows automatically navigate to `/table/CODE` where `CODE` matches the lobby ID.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,6 +27,7 @@
         "jest": "^29.7.0",
         "nodemon": "^3.1.0",
         "prettier": "^3.2.5",
+        "socket.io-client": "^4.8.1",
         "supertest": "^7.1.1"
       }
     },
@@ -2484,6 +2485,45 @@
       "engines": {
         "node": ">=10.2.0"
       }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
@@ -6114,6 +6154,47 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -6791,6 +6872,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,9 +34,10 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.2.5",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",
+    "prettier": "^3.2.5",
+    "socket.io-client": "^4.8.1",
     "supertest": "^7.1.1"
   },
   "jest": {

--- a/backend/tests/socket.startGame.test.js
+++ b/backend/tests/socket.startGame.test.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const express = require('express');
+const Client = require('socket.io-client');
+const { init } = require('../src/socket');
+
+let ioServer, httpServer, addr;
+
+beforeAll((done) => {
+  const app = express();
+  httpServer = http.createServer(app);
+  ioServer = init(httpServer);
+  httpServer.listen(() => {
+    addr = httpServer.address();
+    done();
+  });
+});
+
+afterAll((done) => {
+  ioServer.close();
+  httpServer.close(done);
+});
+
+test('start-game notifies all lobby members', (done) => {
+  const url = `http://localhost:${addr.port}`;
+  const tableId = 'room1';
+  const gm = { _id: 'u1', username: 'GM', role: 'master' };
+  const player = { _id: 'u2', username: 'P1', role: 'player' };
+
+  const c1 = Client(url);
+  const c2 = Client(url);
+
+  let received1 = false;
+  let received2 = false;
+  const check = () => {
+    if (received1 && received2) {
+      c1.close();
+      c2.close();
+      done();
+    }
+  };
+
+  c1.emit('join-lobby', { tableId, user: gm });
+  c2.emit('join-lobby', { tableId, user: player });
+
+  c1.on('game-started', () => {
+    received1 = true;
+    check();
+  });
+  c2.on('game-started', () => {
+    received2 = true;
+    check();
+  });
+
+  // Wait a moment to ensure both clients joined before starting
+  setTimeout(() => {
+    c1.emit('start-game', { tableId });
+  }, 50);
+});

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 const socket = io(import.meta.env.VITE_SOCKET_URL || 'http://localhost:5000');
 
 export default function LobbyPage() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useUserStore();
   const [tableId, setTableId] = useState(null);
   const [players, setPlayers] = useState([]);
@@ -29,10 +29,18 @@ export default function LobbyPage() {
     getCharacter(char).then(setCharacter).catch(() => {});
   }, [char]);
 
-  // generate tableId on mount
+  // get or generate tableId on mount
   useEffect(() => {
-    const id = Math.random().toString(36).substring(2, 8);
-    setTableId(id);
+    const existing = searchParams.get('table');
+    if (existing) {
+      setTableId(existing);
+    } else {
+      const id = Math.random().toString(36).substring(2, 8);
+      setTableId(id);
+      const sp = new URLSearchParams(searchParams);
+      sp.set('table', id);
+      setSearchParams(sp, { replace: true });
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle lobby IDs from the URL so players share a lobby
- redirect everyone to the game table on the `game-started` event
- add a Jest test covering the Socket.IO `start-game` flow
- document manual QA steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc627cf748322b293879f30e3546d