### PR TITLE
Improve login ping handling

### DIFF
--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -16,7 +16,18 @@ function AdminLoginPage() {
   const setUser = useUserStore((s) => s.setUser);
 
   useEffect(() => {
-    api.get('/ping').catch(() => {});
+    let attempts = 0;
+    const ping = () => {
+      api.get('/ping').catch(() => {
+        if (attempts < 2) {
+          attempts++;
+          setTimeout(ping, 1000);
+        } else {
+          showToast('Failed to connect to server', 'error');
+        }
+      });
+    };
+    ping();
   }, []);
 
   const handleSubmit = async (e) => {

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -20,8 +20,19 @@ function LoginPage() {
   const setUser = useUserStore((s) => s.setUser);
 
   useEffect(() => {
-    // Wake the backend in case it was idle
-    api.get("/ping").catch(() => {});
+    // Wake the backend in case it was idle. Retry a few times before giving up.
+    let attempts = 0;
+    const ping = () => {
+      api.get("/ping").catch(() => {
+        if (attempts < 2) {
+          attempts++;
+          setTimeout(ping, 1000);
+        } else {
+          showToast("Failed to connect to server", "error");
+        }
+      });
+    };
+    ping();
   }, []);
 
   const handleSubmit = async (e) => {


### PR DESCRIPTION
## Summary
- retry backend wake-up on login
- show toast when backend can't be reached

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc6291f0c8322baf2d9f73f15de74