### PR TITLE
Update test instructions and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project combines an Express/MongoDB backend with a React frontend.
 ## Setup
 
 1. **Install dependencies**
+   Run the helper script to install packages in both subprojects:
+
    ```bash
-   cd backend && npm install
-   cd ../frontend && npm install
+   ./setup.sh
    ```
 
 2. **Environment variables**
@@ -85,12 +86,12 @@ npm start
 
 ## Running tests
 
-The backend uses **Jest** for its test suite. After installing dependencies you
-can run the tests with:
+Both the backend and frontend use **Jest**. Ensure dependencies are installed in
+each directory (run `./setup.sh` if you haven't already) and then execute:
 
 ```bash
-cd backend
-npm test
+cd backend && npm test
+cd ../frontend && npm test
 ```
 
 ## Linting and formatting

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+echo "Installing backend dependencies..."
+(cd backend && npm install)
+
+echo "Installing frontend dependencies..."
+(cd frontend && npm install)
+


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper to install backend and frontend dependencies
- update installation instructions to use the script
- document that both packages must be installed before running tests

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684de41f66c483229541b00314868a09