### PR TITLE
Use race/profession codes for translations

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -10,7 +10,8 @@ const generateInventory = require('../utils/generateInventory');
 exports.getAllByUser = async (req, res) => {
   try {
     const characters = await Character.find({ user: req.user.id })
-      .populate('race profession');
+      .populate('race', 'name code')
+      .populate('profession', 'name code');
     res.json(characters);
   } catch (err) {
     res.status(500).json({ message: err.message });
@@ -103,7 +104,8 @@ exports.create = async (req, res) => {
 exports.getOne = async (req, res) => {
   try {
     const char = await Character.findOne({ _id: req.params.id, user: req.user.id })
-      .populate('race profession');
+      .populate('race', 'name code')
+      .populate('profession', 'name code');
     if (!char) return res.status(404).json({ message: 'Not found' });
     res.json(char);
   } catch (err) {

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -36,7 +36,8 @@ function init(httpServer) {
         let character = null;
         if (characterId) {
           character = await Character.findById(characterId)
-            .populate('race profession')
+            .populate('race', 'name code')
+            .populate('profession', 'name code')
             .select('name image race profession stats inventory description')
             .lean();
         }
@@ -46,7 +47,8 @@ function init(httpServer) {
         player.online = true;
         if (characterId && !player.character) {
           player.character = await Character.findById(characterId)
-            .populate('race profession')
+            .populate('race', 'name code')
+            .populate('profession', 'name code')
             .select('name image race profession stats inventory description')
             .lean();
         }
@@ -75,7 +77,8 @@ function init(httpServer) {
         let character = null;
         if (characterId) {
           character = await Character.findById(characterId)
-            .populate('race profession')
+            .populate('race', 'name code')
+            .populate('profession', 'name code')
             .select('name image race profession stats inventory description')
             .lean();
         }
@@ -85,7 +88,8 @@ function init(httpServer) {
         player.online = true;
         if (characterId && !player.character) {
           player.character = await Character.findById(characterId)
-            .populate('race profession')
+            .populate('race', 'name code')
+            .populate('profession', 'name code')
             .select('name image race profession stats inventory description')
             .lean();
         }

--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -23,11 +23,11 @@ export default function CharacterCard({
       <h3 className="text-xl text-dndgold text-center font-dnd mb-2">{character.name}</h3>
       <div className="text-base">
         <strong className="text-dndgold">Раса:</strong>{' '}
-        {t('races.' + (character.race?.name || '')) || character.race?.name || '—'}
+        {t('races.' + (character.race?.code || '')) || character.race?.name || '—'}
       </div>
       <div className="text-base">
         <strong className="text-dndgold">Клас:</strong>{' '}
-        {t('classes.' + (character.profession?.name || '')) || character.profession?.name || '—'}
+        {t('classes.' + (character.profession?.code || '')) || character.profession?.name || '—'}
       </div>
 
       <div className="text-sm">

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -13,8 +13,8 @@ export default function PlayerCard({ character, onSelect }) {
       />
       <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
       <p className="text-xs text-center">
-        {t('races.' + (character.race?.name || '')) || character.race?.name} /{' '}
-        {t('classes.' + (character.profession?.name || '')) || character.profession?.name}
+        {t('races.' + (character.race?.code || '')) || character.race?.name} /{' '}
+        {t('classes.' + (character.profession?.code || '')) || character.profession?.name}
       </p>
       {character.stats && (
         <ul className="text-xs grid grid-cols-2 gap-x-2 mt-2">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4,25 +4,25 @@
   "register": "Register",
   "fields_required": "Please fill in all fields",
   "races": {
-    "Human": "Human",
-    "Elf": "Elf",
-    "Orc": "Orc",
-    "Gnome": "Gnome",
-    "Dwarf": "Dwarf",
-    "Halfling": "Halfling",
-    "Demon": "Demon",
-    "Beastkin": "Beastkin",
-    "Angel": "Angel",
-    "Lizardman": "Lizardman"
+    "human": "Human",
+    "elf": "Elf",
+    "orc": "Orc",
+    "gnome": "Gnome",
+    "dwarf": "Dwarf",
+    "halfling": "Halfling",
+    "demon": "Demon",
+    "beastkin": "Beastkin",
+    "angel": "Angel",
+    "lizardman": "Lizardman"
   },
   "classes": {
-    "Warrior": "Warrior",
-    "Mage": "Mage",
-    "Rogue": "Rogue",
-    "Healer": "Healer",
-    "Ranger": "Ranger",
-    "Bard": "Bard",
-    "Paladin": "Paladin"
+    "warrior": "Warrior",
+    "mage": "Mage",
+    "rogue": "Rogue",
+    "healer": "Healer",
+    "ranger": "Ranger",
+    "bard": "Bard",
+    "paladin": "Paladin"
   },
   "stats": {
     "STR": "Strength",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -4,25 +4,25 @@
   "register": "Реєстрація",
   "fields_required": "Заповніть усі поля",
   "races": {
-    "Human": "Людина",
-    "Elf": "Ельф",
-    "Orc": "Орк",
-    "Gnome": "Гном",
-    "Dwarf": "Дварф",
-    "Halfling": "Хафлінг",
-    "Demon": "Демон",
-    "Beastkin": "Звіролюдина",
-    "Angel": "Ангел",
-    "Lizardman": "Ящіролюд"
+    "human": "Людина",
+    "elf": "Ельф",
+    "orc": "Орк",
+    "gnome": "Гном",
+    "dwarf": "Дварф",
+    "halfling": "Хафлінг",
+    "demon": "Демон",
+    "beastkin": "Звіролюдина",
+    "angel": "Ангел",
+    "lizardman": "Ящіролюд"
   },
   "classes": {
-    "Warrior": "Воїн",
-    "Mage": "Маг",
-    "Rogue": "Розбійник",
-    "Healer": "Лікар",
-    "Ranger": "Рейнджер",
-    "Bard": "Бард",
-    "Paladin": "Паладин"
+    "warrior": "Воїн",
+    "mage": "Маг",
+    "rogue": "Розбійник",
+    "healer": "Лікар",
+    "ranger": "Рейнджер",
+    "bard": "Бард",
+    "paladin": "Паладин"
   },
   "stats": {
     "STR": "Сила",

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -21,10 +21,10 @@ export default function CharacterListPage() {
             <h2 className="text-xl text-dndgold">{c.name}</h2>
             <p className="text-base italic mb-2">{c.description}</p>
             <p className="text-xs">
-              Раса: {t('races.' + (c.race?.name || '')) || c.race?.name || '—'}
+              Раса: {t('races.' + (c.race?.code || '')) || c.race?.name || '—'}
             </p>
             <p className="text-xs">
-              Клас: {t('classes.' + (c.profession?.name || '')) || c.profession?.name || '—'}
+              Клас: {t('classes.' + (c.profession?.code || '')) || c.profession?.name || '—'}
             </p>
             <button
               onClick={() => navigate(`/lobby?char=${c._id}`)}

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -122,8 +122,8 @@ export default function LobbyPage() {
             <div>
               <div className="font-bold">{character.name}</div>
               <div className="text-sm">
-                {t('races.' + (character.race?.name || '')) || character.race?.name} &middot;{' '}
-                {t('classes.' + (character.profession?.name || '')) || character.profession?.name}
+                {t('races.' + (character.race?.code || '')) || character.race?.name} &middot;{' '}
+                {t('classes.' + (character.profession?.code || '')) || character.profession?.name}
               </div>
             </div>
           </div>
@@ -140,10 +140,10 @@ export default function LobbyPage() {
                   <>
                     {pl.character.name}
                     {pl.character.race && (
-                      <> – {t('races.' + (pl.character.race?.name || '')) || pl.character.race?.name}</>
+                      <> – {t('races.' + (pl.character.race?.code || '')) || pl.character.race?.name}</>
                     )}
                     {pl.character.profession && (
-                      <> / {t('classes.' + (pl.character.profession?.name || '')) || pl.character.profession?.name}</>
+                      <> / {t('classes.' + (pl.character.profession?.code || '')) || pl.character.profession?.name}</>
                     )}
                   </>
                 ) : (


### PR DESCRIPTION
## Summary
- use `race.code` and `profession.code` in UI translations
- include `code` fields when populating character race and profession
- translate codes using updated locale files

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de41dbd448322a3f6b5c02f60637e