### PR TITLE
Ensure character API returns race/class codes

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -94,7 +94,11 @@ exports.create = async (req, res) => {
     });
 
     await newChar.save();
-    res.status(201).json(newChar);
+
+    const populated = await Character.findById(newChar._id)
+      .populate('race', 'name code')
+      .populate('profession', 'name code');
+    res.status(201).json(populated);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
@@ -129,7 +133,11 @@ exports.update = async (req, res) => {
       { new: true }
     );
     if (!char) return res.status(404).json({ message: 'Not found' });
-    res.json(char);
+
+    const populated = await Character.findById(char._id)
+      .populate('race', 'name code')
+      .populate('profession', 'name code');
+    res.json(populated);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -15,6 +15,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   generateInventory.mockResolvedValue([]);
   jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const q = Promise.resolve({ _id: 'c1', race: { name: 'Elf', code: 'elf' }, profession: { name: 'Mage', code: 'mage' } });
+  q.populate = jest.fn().mockReturnValue(q);
+  Character.findById = jest.fn(() => q);
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- populate race and profession codes in character controller responses
- update unit tests to mock new population queries

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_684de5ee7cf48322921e4a7d9f585c43