### PR TITLE
Prevent form submission reload on empty credentials

### DIFF
--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -31,12 +31,12 @@ function AdminLoginPage() {
   }, []);
 
   const handleSubmit = async (e) => {
+    e.preventDefault();
     setError(null);
     if (!login || !password) {
       showToast(t('fields_required'), 'error');
       return;
     }
-    e.preventDefault();
     setError('');
     setLoading(true);
     try {

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -36,12 +36,12 @@ function LoginPage() {
   }, []);
 
   const handleSubmit = async (e) => {
+    e.preventDefault();
     setError(null);
     if (!login || !password) {
       showToast(t('fields_required'), "error");
       return;
     }
-    e.preventDefault();
     setError("");
     setLoading(true);
     try {


### PR DESCRIPTION
## Summary
- stop the login forms from reloading the page when credentials are empty

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684def23b23083229566a4bbf574c516