### PR TITLE
Disable login button until backend is reachable

### DIFF
--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -13,12 +13,13 @@ function AdminLoginPage() {
   const navigate = useNavigate();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [serverReady, setServerReady] = useState(false);
   const setUser = useUserStore((s) => s.setUser);
 
   useEffect(() => {
     let attempts = 0;
     const ping = () => {
-      api.get('/ping').catch(() => {
+      api.get('/ping').then(() => setServerReady(true)).catch(() => {
         if (attempts < 2) {
           attempts++;
           setTimeout(ping, 1000);
@@ -59,6 +60,9 @@ function AdminLoginPage() {
         <h1 className="text-3xl font-dnd mb-4">Admin Login</h1>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {error && <div className="text-red-400">{error}</div>}
+          {!serverReady && (
+            <div className="text-yellow-300">Connecting to server...</div>
+          )}
           <input
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             placeholder="Login"
@@ -76,7 +80,7 @@ function AdminLoginPage() {
           />
           <button
             type="submit"
-            disabled={loading}
+            disabled={!serverReady || loading}
             className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95 disabled:opacity-50"
           >
             {loading ? 'Вхід...' : t('login')}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -17,13 +17,14 @@ function LoginPage() {
   const navigate = useNavigate();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [serverReady, setServerReady] = useState(false);
   const setUser = useUserStore((s) => s.setUser);
 
   useEffect(() => {
     // Wake the backend in case it was idle. Retry a few times before giving up.
     let attempts = 0;
     const ping = () => {
-      api.get("/ping").catch(() => {
+      api.get("/ping").then(() => setServerReady(true)).catch(() => {
         if (attempts < 2) {
           attempts++;
           setTimeout(ping, 1000);
@@ -66,6 +67,9 @@ function LoginPage() {
         <h1 className="text-3xl font-dnd mb-4">Ласкаво просимо до D&D 5051</h1>
               <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {error && <div className="text-red-400">{error}</div>}
+          {!serverReady && (
+            <div className="text-yellow-300">Connecting to server...</div>
+          )}
           <input
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             placeholder="Кодове ім’я"
@@ -83,7 +87,7 @@ function LoginPage() {
           />
           <button
             type="submit"
-            disabled={loading}
+            disabled={!serverReady || loading}
             className="bg-red-700 hover:bg-red-800 rounded py-2 text-white font-bold transition active:scale-95 disabled:opacity-50"
           >
             {loading ? 'Вхід...' : 'Увійти'}


### PR DESCRIPTION
## Summary
- disable login until server responds
- show connecting message when backend is unreachable

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684def212b908322a587d43730f626d3