### PR TITLE
Add AxiosToastProvider to main

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { SettingsProvider } from './context/SettingsContext';
 import { ToastProvider } from './context/ToastContext';
+import AxiosToastProvider from './components/AxiosToastProvider';
 import './i18n';
 import './index.css';
 import './App.css';
@@ -12,6 +13,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <SettingsProvider>
       <ToastProvider>
+        <AxiosToastProvider />
         <BrowserRouter>
           <App />
         </BrowserRouter>


### PR DESCRIPTION
## Summary
- import AxiosToastProvider in frontend entry
- render AxiosToastProvider inside ToastProvider to show request errors

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684defe6c6208322ae79b2b43ecdb792