### PR TITLE
Add error handling for character creation API

### DIFF
--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -1,18 +1,24 @@
 
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom'
-import { createCharacter } from '../utils/api'
+import { useNavigate } from 'react-router-dom';
+import { createCharacter } from '../utils/api';
+import { useToast } from '../context/ToastContext';
 
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const newChar = await createCharacter({ name, description });
-    if (newChar && newChar._id) {
-      navigate('/lobby?char=' + newChar._id);
+    try {
+      const newChar = await createCharacter({ name, description });
+      if (newChar && newChar._id) {
+        navigate('/lobby?char=' + newChar._id);
+      }
+    } catch (err) {
+      showToast(err.message || 'Помилка створення персонажа', 'error');
     }
   };
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -43,6 +43,10 @@ export const createCharacter = async (data) => {
     headers,
     body,
   });
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || res.statusText);
+  }
   return res.json();
 };
 


### PR DESCRIPTION
## Summary
- handle failed response in `createCharacter`
- show toast errors when character creation fails

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684def1f93c08322940432e48aa18218