### PR TITLE
Add error handling for character creation API

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,8 +1,7 @@
-import api from "../api/axios";
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
 import LogoutButton from "../components/LogoutButton";
-import { getRaces, getProfessions } from '../utils/api';
+import { createCharacter, getRaces, getProfessions } from '../utils/api';
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
@@ -28,22 +27,14 @@ export default function CharacterCreatePage() {
         return;
       }
 
-      let payload;
-      let headers;
-      if (image) {
-        payload = new FormData();
-        payload.append('name', form.name);
-        payload.append('image', image);
-        headers = { 'Content-Type': 'multipart/form-data' };
-      } else {
-        payload = { name: form.name };
-        headers = { 'Content-Type': 'application/json' };
-      }
-      await api.post("/character", payload, { headers });
+      const payload = { name: form.name };
+      if (image) payload.image = image;
+
+      await createCharacter(payload);
       navigate("/profile");
     } catch (err) {
       console.error(err);
-      setError("Помилка створення персонажа");
+      setError(err.message || "Помилка створення персонажа");
     }
   };
 

--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -1,18 +1,23 @@
 
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom'
-import { createCharacter } from '../utils/api'
+import { useNavigate } from 'react-router-dom';
+import { createCharacter } from '../utils/api';
 
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const newChar = await createCharacter({ name, description });
-    if (newChar && newChar._id) {
-      navigate('/lobby?char=' + newChar._id);
+    try {
+      const newChar = await createCharacter({ name, description });
+      if (newChar && newChar._id) {
+        navigate('/lobby?char=' + newChar._id);
+      }
+    } catch (err) {
+      setError(err.message || 'Помилка створення персонажа');
     }
   };
 
@@ -32,6 +37,7 @@ const CreateCharacterPage = () => {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <button type="submit">Створити</button>
       </form>
     </div>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -43,7 +43,11 @@ export const createCharacter = async (data) => {
     headers,
     body,
   });
-  return res.json();
+  const result = await res.json();
+  if (!res.ok) {
+    throw new Error(result?.message || res.statusText);
+  }
+  return result;
 };
 
 export const deleteCharacter = async (id) => {


### PR DESCRIPTION
## Summary
- handle errors in `createCharacter` API helper
- show character creation errors in `CreateCharacterPage` and `CharacterCreatePage`

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684defe6c0448322a0bd21b83c26fe88