### PR TITLE
Remove stray text tokens from pages

### DIFF
--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -64,7 +64,6 @@ function AdminLoginPage() {
           {!serverReady && (
             <div className="text-yellow-300">Connecting to server...</div>
           )}
- main
           <input
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             placeholder="Login"

--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { createCharacter } from '../utils/api';
 
 import { useToast } from '../context/ToastContext';
- main
 
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');
@@ -22,7 +21,6 @@ const CreateCharacterPage = () => {
     } catch (err) {
 
       setError(err.message || 'Помилка створення персонажа');
- main
     }
   };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -71,7 +71,6 @@ function LoginPage() {
           {!serverReady && (
             <div className="text-yellow-300">Connecting to server...</div>
           )}
- main
           <input
             className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300"
             placeholder="Кодове ім’я"


### PR DESCRIPTION
## Summary
- clean up leftover `main` tokens in login pages
- ensure create character page has no stray text

## Testing
- `npx esbuild src/pages/AdminLoginPage.jsx --format=esm --outfile=/tmp/out.js`
- `npx esbuild src/pages/LoginPage.jsx --format=esm --outfile=/tmp/out.js`
- `npx esbuild src/pages/CreateCharacterPage.jsx --format=esm --outfile=/tmp/out.js`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684df5cfc5ac8322b281f9ab3b253e0a