### PR TITLE
Ensure Item model is registered

### DIFF
--- a/backend/src/models/StartingSet.js
+++ b/backend/src/models/StartingSet.js
@@ -1,5 +1,6 @@
 // backend/models/StartingSet.js
 const mongoose = require('mongoose');
+require('./Item');
 
 const startingSetSchema = new mongoose.Schema({
   classCode: { type: String, required: true },


### PR DESCRIPTION
## Summary
- register the `Item` model in `StartingSet`

## Testing
- `npm --prefix backend test`
- manual check that `mongoose.modelNames()` includes `Item` after requiring `StartingSet`

------
https://chatgpt.com/codex/tasks/task_e_684df9a3df9883229ca2f633b90f6dcb