### PR TITLE
Wrap DiceBox and align to chat

### DIFF
--- a/frontend/src/components/DiceBox.jsx
+++ b/frontend/src/components/DiceBox.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export default function DiceBox() {
+export default function DiceBox({ className = '' }) {
   const [diceResult, setDiceResult] = useState(null);
   const [diceAnim, setDiceAnim] = useState(false);
 
@@ -16,27 +16,29 @@ export default function DiceBox() {
   };
 
   return (
-    <div className="flex flex-col items-center">
-      <div className="flex gap-2">
-        <button
-          className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
-          onClick={() => rollDice('d20')}
-        >
-          Кинути D20
-        </button>
-        <button
-          className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
-          onClick={() => rollDice('d6')}
-        >
-          Кинути D6
-        </button>
+    <div className={`border border-dndgold rounded-2xl p-2 bg-[#25160f]/80 ${className}`}>
+      <div className="flex flex-col items-center">
+        <div className="flex gap-2">
+          <button
+            className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
+            onClick={() => rollDice('d20')}
+          >
+            Кинути D20
+          </button>
+          <button
+            className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
+            onClick={() => rollDice('d6')}
+          >
+            Кинути D6
+          </button>
+        </div>
+        {diceAnim && (
+          <div className="animate-bounce text-3xl text-dndgold mt-2"> ...</div>
+        )}
+        {diceResult && !diceAnim && (
+          <div className="text-xl text-dndgold font-bold mt-2">Результат: {diceResult}</div>
+        )}
       </div>
-      {diceAnim && (
-        <div className="animate-bounce text-3xl text-dndgold mt-2"> ...</div>
-      )}
-      {diceResult && !diceAnim && (
-        <div className="text-xl text-dndgold font-bold mt-2">Результат: {diceResult}</div>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -107,14 +107,14 @@ export default function GameTablePage() {
               <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
               <MusicPlayer isGM={isGM} />
               <GMPanel tableId={tableId} socket={socket} players={players} />
-              <DiceBox />
+              <DiceBox className="self-end" />
             </>
           ) : (
             <>
               <div className="md:w-72 w-full">
                 <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
               </div>
-              <DiceBox />
+              <DiceBox className="self-end" />
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- style `DiceBox` with a bordered container
- allow passing `className` to `DiceBox`
- align dice box to bottom of chat in `GameTablePage`

## Testing
- `./setup.sh`
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684e02b9a310832293604e032ccc19f6