### PR TITLE
Adjust chat layout

### DIFF
--- a/frontend/src/components/ChatComponent.jsx
+++ b/frontend/src/components/ChatComponent.jsx
@@ -18,9 +18,9 @@ export default function ChatComponent({ tableId, user, messages, socket }) {
   };
 
   return (
-    <div className="border border-dndgold rounded-2xl p-2 bg-[#25160f]/80">
+    <div className="border border-dndgold rounded-2xl p-2 bg-[#25160f]/80 w-60">
       <div className="flex flex-col h-full">
-        <div className="flex-1 max-h-60 overflow-y-auto bg-[#20100a]/70 p-2 rounded-xl mb-2">
+        <div className="flex-1 max-h-32 overflow-y-auto bg-[#20100a]/70 p-2 rounded-xl mb-2">
           {messages.map((m, i) => (
             <div key={i}><b>{m.user}:</b> {m.text}</div>
           ))}

--- a/frontend/src/components/GMPanel.jsx
+++ b/frontend/src/components/GMPanel.jsx
@@ -1,7 +1,7 @@
 
 import { useState } from 'react';
 
-export default function GMPanel({ tableId, socket, players }) {
+export default function GMPanel({ tableId, socket, players, className = '' }) {
   const [monsterName, setMonsterName] = useState("");
   const [mapUrl, setMapUrl] = useState("");
   const [initiativeList, setInitiativeList] = useState([]);
@@ -34,7 +34,7 @@ export default function GMPanel({ tableId, socket, players }) {
   };
 
   return (
-    <div className="bg-[#25160f]/80 rounded-2xl p-4 mb-2 mt-4 text-center">
+    <div className={`bg-[#25160f]/80 rounded-2xl p-4 mb-2 mt-4 text-center ${className}`}>
       <div className="text-dndgold text-xl font-bold mb-2">GM-панель</div>
       {/* Додавання монстра */}
       <div className="mb-2">

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import api from '../api/axios';
 import { useUserStore } from '../store/user';
 
-export default function MusicPlayer({ isGM }) {
+export default function MusicPlayer({ isGM, className = '' }) {
   const [tracks, setTracks] = useState([]);
   const [current, setCurrent] = useState(null);
   const [volume, setVolume] = useState(() => {
@@ -55,7 +55,7 @@ export default function MusicPlayer({ isGM }) {
   };
 
   return (
-    <div className="bg-[#25160f]/80 rounded-2xl p-4 mb-4 text-dndgold">
+    <div className={`bg-[#25160f]/80 rounded-2xl p-4 mb-4 text-dndgold ${className}`}>
       <div className="font-dnd text-xl mb-2">Музика</div>
       {current && (
         <ReactPlayer url={current.url} playing controls={true} volume={volume} width="100%" height="50px" />

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -100,14 +100,14 @@ export default function GameTablePage() {
         </div>
         {/* Нижня панель */}
         <div
-          className={`md:absolute md:bottom-4 md:left-1/2 md:-translate-x-1/2 z-20 mt-4 md:mt-0 flex gap-4 ${isGM ? 'flex-row flex-wrap justify-center items-end md:w-auto w-full' : 'flex-row justify-center w-full'}`}
+          className={`md:absolute md:bottom-4 md:left-1/2 md:-translate-x-1/2 z-20 mt-4 md:mt-0 flex gap-4 ${isGM ? 'flex-row flex-wrap md:flex-nowrap justify-center items-end md:w-auto w-full' : 'flex-row justify-center w-full'}`}
         >
           {isGM ? (
             <>
               <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
-              <MusicPlayer isGM={isGM} />
-              <GMPanel tableId={tableId} socket={socket} players={players} />
-              <DiceBox className="self-end" />
+              <MusicPlayer isGM={isGM} className="w-60" />
+              <GMPanel tableId={tableId} socket={socket} players={players} className="w-60" />
+              <DiceBox className="self-end w-40" />
             </>
           ) : (
             <>


### PR DESCRIPTION
## Summary
- shrink chat height and width
- allow smaller GM panel and music player components
- align bottom panel in a single row

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0695a7b08322a55f52c12d83374d