### PR TITLE
Update env docs and preset avatar info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This project combines an Express/MongoDB backend with a React frontend.
    Copy `backend/.env.example` to `backend/.env` and adjust the values:
    - `MONGO_URI` – MongoDB connection string
    - `JWT_SECRET` – secret used for signing tokens
-   - `OPENAI_API_KEY` – API key for generating images and descriptions
    - `PORT` – optional server port (defaults to `5000`)
    - `CLIENT_URL` – allowed origin(s) for CORS. Set this to the URL of your frontend (comma separated to allow multiple, e.g. `http://localhost:5173,https://example.com`).
 
@@ -47,7 +46,7 @@ cd backend
 npm run dev
 ```
 
-The backend automatically creates `uploads/` and `uploads/maps/` directories for uploaded files and exposes them from the `/uploads` path.
+The backend automatically creates `uploads/` and `uploads/maps/` directories for uploaded files and exposes them from the `/uploads` path. Preset avatars are served from `/avatars`.
 
 ### Frontend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,4 @@
 MONGO_URI=mongodb://localhost:27017/ddua
 JWT_SECRET=your_jwt_secret
-OPENAI_API_KEY=your_openai_api_key
 PORT=5000
 CLIENT_URL=http://localhost:5173


### PR DESCRIPTION
## Summary
- remove reference to OpenAI from README and env example
- document preset avatars served from `/avatars`

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e08b7e8108322ad789b93abd91620