### PR TITLE
Add avatar storage evaluation and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Thank you for helping improve this project! Please follow these guidelines when submitting changes.
+
+## Development setup
+- Run `./setup.sh` to install backend and frontend dependencies.
+- See `MANUAL_QA.md` for manual testing steps.
+
+## Binary assets
+Avatar images and other static artwork are stored directly in this repository. The current avatar assets occupy about **40 KB** in total.
+
+Binary assets are allowed, but please keep them small and commit only artwork needed by the application. Large media files should be hosted externally (e.g. object storage or CDN) and referenced from the code.
+
+If you add new images, update this document with the approximate total size after your changes.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ const inventory = generateInventory('Orc', 'Warrior');
 // => ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я', 'Кістяний талісман']
 ```
 
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for development and binary asset guidelines.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/avatar_storage.md
+++ b/docs/avatar_storage.md
@@ -1,0 +1,17 @@
+# Avatar image storage evaluation
+
+## Current status
+- The repository includes avatar assets in `frontend/public/avatars` and a default avatar in `frontend/public/default-avatar.png`.
+- These assets total about 40 KB.
+- Other static images such as map backgrounds account for roughly 8.5 MB.
+
+## Using a CDN or object storage
+Hosting the avatars on a CDN (Content Delivery Network) or object storage service (e.g. S3, Cloudflare R2, GCS) would:
+- reduce repository size and clone times;
+- allow efficient caching and global distribution; and
+- require additional configuration and infrastructure (access keys, base URL, upload process).
+
+Given the small size and infrequent updates of the current avatars, the added complexity may not be justified.
+
+## Recommendation
+Keeping the avatars in git is acceptable while their total size remains under 100 KB. Reevaluate if more binary images are added or if users start uploading many custom avatars.


### PR DESCRIPTION
## Summary
- evaluate whether to keep avatars in Git
- document contribution process and binary asset policy

## Testing
- `./setup.sh`
- `cd backend && npm test` *(fails: start-game notifies all lobby members)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e08bad0c4832298a64b6537b6130b