### PR TITLE
Adjust game table panel layouts

### DIFF
--- a/frontend/src/components/GMPanel.jsx
+++ b/frontend/src/components/GMPanel.jsx
@@ -36,31 +36,40 @@ export default function GMPanel({ tableId, socket, players, className = '' }) {
   return (
     <div className={`bg-[#25160f]/80 rounded-2xl p-4 mb-2 mt-4 text-center ${className}`}>
       <div className="text-dndgold text-xl font-bold mb-2">GM-панель</div>
-      {/* Додавання монстра */}
-      <div className="mb-2">
-        <input
-          className="rounded px-2 py-1 mr-2"
-          value={monsterName}
-          onChange={e => setMonsterName(e.target.value)}
-          placeholder="Ім'я монстра"
-        />
-        <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={addMonster}>Додати монстра</button>
-      </div>
-      {/* Кік гравців */}
-      <div className="mb-2">
-        {players.map(p => (
-          <button key={p.user} onClick={() => kick(p.user)} className="bg-dndred px-3 py-1 rounded-xl m-1 text-white">{p.name} Кік</button>
-        ))}
-      </div>
-      {/* Ініціатива */}
-      <div className="mb-2">
-        <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={handleInitiativeInput}>Згенерувати ініціативу</button>
-        <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl ml-2" onClick={startInitiative}>Почати ініціативу</button>
-      </div>
-      {/* Оновити карту */}
-      <div>
-        <input className="rounded px-2 py-1 mr-2" value={mapUrl} onChange={e => setMapUrl(e.target.value)} placeholder="Посилання на карту" />
-        <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={updateMap}>Оновити карту</button>
+      <div className="flex flex-col gap-2">
+        {/* Додавання монстра */}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <input
+            className="rounded px-2 py-1"
+            value={monsterName}
+            onChange={e => setMonsterName(e.target.value)}
+            placeholder="Ім'я монстра"
+          />
+          <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={addMonster}>Додати монстра</button>
+        </div>
+        {/* Кік гравців */}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {players.map(p => (
+            <button key={p.user} onClick={() => kick(p.user)} className="bg-dndred px-3 py-1 rounded-xl text-white">
+              {p.name} Кік
+            </button>
+          ))}
+        </div>
+        {/* Ініціатива */}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={handleInitiativeInput}>Згенерувати ініціативу</button>
+          <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={startInitiative}>Почати ініціативу</button>
+        </div>
+        {/* Оновити карту */}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <input
+            className="rounded px-2 py-1"
+            value={mapUrl}
+            onChange={e => setMapUrl(e.target.value)}
+            placeholder="Посилання на карту"
+          />
+          <button className="bg-dndgold text-dndred font-dnd px-4 py-2 rounded-xl" onClick={updateMap}>Оновити карту</button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -64,7 +64,7 @@ export default function MusicPlayer({ isGM, className = '' }) {
         <span className="text-sm">Гучність</span>
         <input type="range" min={0} max={1} step={0.01} value={volume} onChange={e => changeVolume(parseFloat(e.target.value))} />
       </div>
-      <ul className="divide-y divide-dndgold/20 max-h-40 overflow-y-auto text-sm">
+      <ul className="divide-y divide-dndgold/20 max-h-32 overflow-y-auto text-sm">
         {tracks.map(track => (
           <li key={track._id} className="flex justify-between items-center py-1">
             <button onClick={() => setCurrent(track)} className="hover:underline flex-1 text-left">

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -100,13 +100,13 @@ export default function GameTablePage() {
         </div>
         {/* Нижня панель */}
         <div
-          className={`md:absolute md:bottom-4 md:left-1/2 md:-translate-x-1/2 z-20 mt-4 md:mt-0 flex gap-4 ${isGM ? 'flex-row flex-wrap md:flex-nowrap justify-center items-end md:w-auto w-full' : 'flex-row justify-center w-full'}`}
+          className={`md:absolute md:bottom-4 md:left-1/2 md:-translate-x-1/2 z-20 mt-4 md:mt-0 flex flex-wrap gap-4 ${isGM ? 'justify-center items-end md:w-auto w-full' : 'justify-center w-full'}`}
         >
           {isGM ? (
             <>
               <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
-              <MusicPlayer isGM={isGM} className="w-60" />
-              <GMPanel tableId={tableId} socket={socket} players={players} className="w-60" />
+              <MusicPlayer isGM={isGM} className="w-48" />
+              <GMPanel tableId={tableId} socket={socket} players={players} className="w-48" />
               <DiceBox className="self-end w-40" />
             </>
           ) : (


### PR DESCRIPTION
## Summary
- shrink MusicPlayer & GMPanel widths to reduce clutter
- allow wrapping in bottom control bar
- limit MusicPlayer track list height
- compact GMPanel layout into horizontal rows

## Testing
- `npm test` in `backend`
- `npm install` && `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684e0c735f008322a799b1d17d312017