### PR TITLE
Support specifying race and class on character creation

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -21,7 +21,7 @@ exports.getAllByUser = async (req, res) => {
 // Створити персонажа
 exports.create = async (req, res) => {
   try {
-    let { name, description, image } = req.body;
+    let { name, description, image, raceId, professionId } = req.body;
 
     if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 50) {
       return res.status(400).json({ message: 'Invalid name' });
@@ -42,17 +42,29 @@ exports.create = async (req, res) => {
     const uploaded = req.file ? `/uploads/avatars/${req.file.filename}` : null;
 
 
-    // Обрати рандомно расу, професію і базові стати з колекції
-  let race = await Race.aggregate([{ $sample: { size: 1 } }]);
-  if (!race.length) {
-    const fallback = await Race.find().limit(1);
-    race = fallback;
+    // Обрати расу та професію (використати передані id або згенерувати випадково)
+  let race;
+  if (raceId) {
+    const found = await Race.findById(raceId);
+    race = found ? [found] : [];
+  } else {
+    race = await Race.aggregate([{ $sample: { size: 1 } }]);
+    if (!race.length) {
+      const fallback = await Race.find().limit(1);
+      race = fallback;
+    }
   }
 
-  let profession = await Profession.aggregate([{ $sample: { size: 1 } }]);
-  if (!profession.length) {
-    const fallback = await Profession.find().limit(1);
-    profession = fallback;
+  let profession;
+  if (professionId) {
+    const found = await Profession.findById(professionId);
+    profession = found ? [found] : [];
+  } else {
+    profession = await Profession.aggregate([{ $sample: { size: 1 } }]);
+    if (!profession.length) {
+      const fallback = await Profession.find().limit(1);
+      profession = fallback;
+    }
   }
 
   if (!race.length || !profession.length) {

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -144,4 +144,28 @@ describe('Character Controller - create', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ message: 'Invalid image' });
   });
+
+  it('uses provided raceId and professionId', async () => {
+    Race.findById.mockResolvedValue({ _id: 'r2', name: 'Orc', code: 'orc' });
+    Profession.findById.mockResolvedValue({ _id: 'p2', name: 'Rogue', code: 'rogue' });
+
+    let saved;
+    Character.mockImplementation(data => {
+      saved = data;
+      return { save: jest.fn().mockResolvedValue(data) };
+    });
+
+    const req = { user: { id: 'u1' }, body: { name: 'Hero', raceId: 'r2', professionId: 'p2' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(Race.findById).toHaveBeenCalledWith('r2');
+    expect(Profession.findById).toHaveBeenCalledWith('p2');
+    expect(Race.aggregate).not.toHaveBeenCalled();
+    expect(Profession.aggregate).not.toHaveBeenCalled();
+    expect(saved.race).toBe('r2');
+    expect(saved.profession).toBe('p2');
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
 });


### PR DESCRIPTION
## Summary
- allow `characterController.create` to honour `raceId` and `professionId`
- test that create uses the provided ids

## Testing
- `cd backend && npm test --silent`
- `cd ../frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684e82d4408c8322aa591fdd2ebe2a9a