### PR TITLE
Add tests for ai util

### DIFF
--- a/backend/src/utils/ai.js
+++ b/backend/src/utils/ai.js
@@ -7,8 +7,20 @@ const fs = require('fs');
 const path = require('path');
 
 exports.generateCharacterImage = async (description) => {
-  // Приклад з DALL-E або Stable Diffusion (через proxy)
-  // Тут лише шаблон
+  // If no API key is provided, fall back to preset avatars bundled in the repo
+  if (!process.env.OPENAI_API_KEY) {
+    try {
+      const avatarsDir = path.join(__dirname, '..', '..', '..', 'frontend', 'public', 'avatars');
+      const files = fs.readdirSync(avatarsDir).filter(f => !f.startsWith('.'));
+      if (files.length === 0) return '';
+      const file = files[Math.floor(Math.random() * files.length)];
+      return `/avatars/${file}`;
+    } catch {
+      return '';
+    }
+  }
+
+  // Example integration with a remote AI service (e.g. DALL-E or Stable Diffusion)
   const res = await fetch('https://api.openai.com/v1/images/generations', {
     method: 'POST',
     headers: {

--- a/backend/tests/ai.util.test.js
+++ b/backend/tests/ai.util.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+
+const { generateCharacterImage } = require('../src/utils/ai');
+
+describe('generateCharacterImage fallback', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns random avatar path', async () => {
+    jest.spyOn(fs, 'readdirSync').mockReturnValue(['a.png', 'b.png']);
+
+    const path = await generateCharacterImage('desc');
+
+    expect(path.startsWith('/avatars/')).toBe(true);
+  });
+
+  it('returns empty string when no files', async () => {
+    jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
+
+    const path = await generateCharacterImage('desc');
+
+    expect(path).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- implement fallback avatar logic in `generateCharacterImage`
- add util tests for AI image generator when using preset avatars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e89f2c5408322a45f2884747f4921