### PR TITLE
Fix race/class display by using translations

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -75,7 +75,7 @@ export default function CharacterCreatePage() {
           <option value="">Оберіть расу</option>
           {races.map((r) => (
             <option key={r._id || r.id || r.code} value={r._id || r.id}>
-              {r.name}
+              {t('races.' + (r.code || '')) || r.name}
             </option>
           ))}
         </select>
@@ -89,7 +89,7 @@ export default function CharacterCreatePage() {
           <option value="">Оберіть клас</option>
           {professions.map((p) => (
             <option key={p._id || p.id || p.code} value={p._id || p.id}>
-              {p.name}
+              {t('classes.' + (p.code || '')) || p.name}
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- pull translation values for races and professions when creating a character

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8cc0ca4483229a22a8932eacab45