### PR TITLE
Update README and refine tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ npm run format
 
 ## Character Basics
 
-Characters use five core statistics which start at **10** each:
+Every adventurer starts with five basic attributes. All of them have a value of
+**10** before any racial or class adjustments are applied:
 
 - **STR** – Strength
 - **DEX** – Dexterity
@@ -116,34 +117,37 @@ Characters use five core statistics which start at **10** each:
 
 ### Races and Bonuses
 
-Ten playable races provide bonuses to these stats:
+Choosing a race grants specific bonuses to your starting stats:
 
-- Human – +1 to all stats
-- Elf – +2 DEX, +1 INT
-- Orc – +2 STR, +1 CON
-- Gnome – +2 CON, +1 INT
-- Dwarf – +2 STR, +1 CHA
-- Halfling – +2 DEX, +1 CHA
-- Demon – +2 INT, +1 CHA
-- Beastkin – +2 DEX, +1 CON
-- Angel – +2 CHA, +1 INT
-- Lizardman – +2 STR, +1 CON
+- **Human** – +1 to all stats
+- **Elf** – +2 DEX, +1 INT
+- **Orc** – +2 STR, +1 CON
+- **Gnome** – +2 CON, +1 INT
+- **Dwarf** – +2 STR, +1 CHA
+- **Halfling** – +2 DEX, +1 CHA
+- **Demon** – +2 INT, +1 CHA
+- **Beastkin** – +2 DEX, +1 CON
+- **Angel** – +2 CHA, +1 INT
+- **Lizardman** – +2 STR, +1 CON
 
 ### Classes and Minimums
 
-Seven classes require minimum statistics:
+Each of the seven classes expects certain ability thresholds before the hero can
+take up the role:
 
-- Warrior – STR 13, CON 12
-- Mage – INT 13, CHA 11
-- Rogue – DEX 13, INT 11
-- Healer – CHA 13, CON 11
-- Ranger – DEX 12, STR 12
-- Bard – CHA 13, DEX 12
-- Paladin – STR 13, CHA 13
+- **Warrior** – STR 13, CON 12
+- **Mage** – INT 13, CHA 11
+- **Rogue** – DEX 13, INT 11
+- **Healer** – CHA 13, CON 11
+- **Ranger** – DEX 12, STR 12
+- **Bard** – CHA 13, DEX 12
+- **Paladin** – STR 13, CHA 13
 
 ### Stat Generation
 
-When creating a character, the race bonuses are applied first. Any class minimums are enforced next. All remaining stats are randomised between **8** and **15** but never lowered below their current values.
+When generating stats, race bonuses apply first. Class minimums then raise any
+insufficient attributes. Finally, untouched stats are randomised between **8**
+and **15**, but never drop below their current value.
 
 ```js
 const stats = generateStats('Elf', 'Mage');
@@ -152,7 +156,9 @@ const stats = generateStats('Elf', 'Mage');
 
 ### Starter Inventory
 
-Each class begins with a predefined set of equipment which can be supplemented by race-specific items. The `generateInventory` utility merges these sets when a character is created.
+Each class provides a starter kit of equipment. Race specific trinkets are then
+added to the pack. The `generateInventory` helper merges both lists when a
+character is created.
 
 ```js
 const inventory = generateInventory('Orc', 'Warrior');

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -53,13 +53,18 @@ describe('Character Controller - create', () => {
     expect(res.json).toHaveBeenCalled();
   });
 
-  it('passes codes to generateInventory', async () => {
+  it('passes codes to generateInventory and saves its result', async () => {
     Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
     Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
 
-    generateInventory.mockResolvedValue([]);
+    const inv = [{ item: 'Test', amount: 1, bonus: {} }];
+    generateInventory.mockResolvedValue(inv);
 
-    Character.mockImplementation(data => ({ save: jest.fn().mockResolvedValue(data) }));
+    let saved;
+    Character.mockImplementation(data => {
+      saved = data;
+      return { save: jest.fn().mockResolvedValue(data) };
+    });
 
     const req = { user: { id: 'u1' }, body: { name: 'Hero' } };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -67,6 +72,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(generateInventory).toHaveBeenCalledWith('elf', 'mage');
+    expect(saved.inventory).toEqual(inv);
   });
 
   it('returns 400 if races or professions are missing', async () => {

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -18,12 +18,11 @@ describe('generateInventory', () => {
     const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    const names = items.map(i => i.item);
-    expect(names).toEqual([
-      'Меч',
-      'Шкіряна броня',
-      'Зілля здоров’я',
-      'Кістяний талісман'
+    expect(items).toEqual([
+      { item: 'Меч', amount: 1, bonus: {} },
+      { item: 'Шкіряна броня', amount: 1, bonus: {} },
+      { item: 'Зілля здоров’я', amount: 1, bonus: {} },
+      { item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }
     ]);
   });
 
@@ -34,12 +33,11 @@ describe('generateInventory', () => {
     const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    const names = items.map(i => i.item);
-    expect(names).toEqual([
-      'Сокира',
-      'Щит',
-      'Зілля здоров’я',
-      'Кістяний талісман'
+    expect(items).toEqual([
+      { item: 'Сокира', amount: 1, bonus: {} },
+      { item: 'Щит', amount: 1, bonus: {} },
+      { item: 'Зілля здоров’я', amount: 1, bonus: {} },
+      { item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }
     ]);
   });
 


### PR DESCRIPTION
## Summary
- rewrite character generation overview in README
- check inventory `amount` and `bonus` in `generateInventory` tests
- ensure character creation stores generated inventory

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684e94561a088322a88836ce65fc3868