### PR TITLE
Update seeding and stats

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -49,32 +49,26 @@ async function seed() {
   // ];
   // const characteristics = ['HP', 'MP', 'Strength', 'Agility', 'Intellect'];
 
-  const baseRaces = [
-    { code: 'human', name: 'Людина' },
-    { code: 'elf', name: 'Ельф' },
-    { code: 'orc', name: 'Орк' },
-    { code: 'gnome', name: 'Гном' },
-    { code: 'dwarf', name: 'Дварф' },
-    { code: 'halfling', name: 'Напіврослик' },
-    { code: 'demon', name: 'Демон' },
-    { code: 'beastkin', name: 'Звіролюд' },
-    { code: 'angel', name: 'Ангел' },
-    { code: 'lizardman', name: 'Ящіролюд' },
+  // Gendered races
+  const races = [
+    { code: 'human_male', name: 'Людина (чоловік)' },
+    { code: 'human_female', name: 'Людина (жінка)' },
+    { code: 'elf_male', name: 'Ельф (чоловік)' },
+    { code: 'elf_female', name: 'Ельф (жінка)' },
+    { code: 'orc_male', name: 'Орк (чоловік)' },
+    { code: 'orc_female', name: 'Орк (жінка)' },
+    { code: 'gnome_male', name: 'Гном (чоловік)' },
+    { code: 'gnome_female', name: 'Гном (жінка)' },
+    { code: 'dwarf_male', name: 'Дварф (чоловік)' },
+    { code: 'dwarf_female', name: 'Дварф (жінка)' },
   ];
-
-  const races = [];
-  for (const r of baseRaces) {
-    races.push({ code: `${r.code}_male`, name: `${r.name} (чоловік)` });
-    races.push({ code: `${r.code}_female`, name: `${r.name} (жінка)` });
-  }
   const professions = [
     { code: 'warrior', name: 'Воїн' },
     { code: 'mage', name: 'Маг' },
-    { code: 'rogue', name: 'Шахрай' },
-    { code: 'healer', name: 'Цілитель' },
-    { code: 'ranger', name: 'Рейнджер' },
+    { code: 'archer', name: 'Лучник' },
+    { code: 'paladin', name: 'Паладин' },
     { code: 'bard', name: 'Бард' },
-    { code: 'paladin', name: 'Паладин' }
+    { code: 'healer', name: 'Цілитель' }
   ];
   const characteristics = [
     'health',
@@ -113,19 +107,6 @@ async function seed() {
         { item: 'Книга заклять' }
       ]
     },
-    rogue: {
-      weapon: [
-        { item: 'Кинджал', bonus: { agility: 1 } },
-        { item: 'Короткий меч', bonus: { agility: 1 } }
-      ],
-      armor: [
-        { item: 'Плащ тіні', bonus: { agility: 1 } },
-        { item: 'Легка броня', bonus: { agility: 1 } }
-      ],
-      misc: [
-        { item: 'Відмички' }
-      ]
-    },
     healer: {
       weapon: [
         { item: 'Жезл лікування', bonus: { charisma: 1 } },
@@ -139,7 +120,7 @@ async function seed() {
         { item: 'Зілля лікування' }
       ]
     },
-    ranger: {
+    archer: {
       weapon: [
         { item: 'Лук', bonus: { agility: 1 } },
         { item: 'Арбалет', bonus: { agility: 1 } }
@@ -179,16 +160,11 @@ async function seed() {
   };
 
   const raceInventory = {
+    human: [{ item: 'Монета удачі', bonus: { charisma: 1 } }],
     elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
     orc: [{ item: 'Кістяний талісман', bonus: { strength: 1 } }],
-    human: [{ item: 'Монета удачі', bonus: { charisma: 1 } }],
     gnome: [{ item: 'Гвинтовий ключ' }],
-    dwarf: [{ item: 'Похідна кружка', bonus: { health: 1 } }],
-    halfling: [{ item: 'Трубка та тютюн', bonus: { charisma: 1 } }],
-    demon: [{ item: 'Темний камінь', bonus: { intellect: 1 } }],
-    beastkin: [{ item: 'Кігтістий амулет', bonus: { agility: 1 } }],
-    angel: [{ item: 'Пір’я з крила', bonus: { charisma: 1 } }],
-    lizardman: [{ item: 'Луска пращура', bonus: { health: 1 } }]
+    dwarf: [{ item: 'Похідна кружка', bonus: { health: 1 } }]
   };
 
   if (await Race.countDocuments() === 0) {

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -2,16 +2,11 @@
 const StartingSet = require('../models/StartingSet');
 
 const raceInventory = {
+  human: [{ item: 'Монета удачі', amount: 1, bonus: { charisma: 1 } }],
   elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
   orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { strength: 1 } }],
-  human: [{ item: 'Монета удачі', amount: 1, bonus: { charisma: 1 } }],
   gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
-  dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { health: 1 } }],
-  halfling: [{ item: 'Трубка та тютюн', amount: 1, bonus: { charisma: 1 } }],
-  demon: [{ item: 'Темний камінь', amount: 1, bonus: { intellect: 1 } }],
-  beastkin: [{ item: 'Кігтістий амулет', amount: 1, bonus: { agility: 1 } }],
-  angel: [{ item: 'Пір’я з крила', amount: 1, bonus: { charisma: 1 } }],
-  lizardman: [{ item: 'Луска пращура', amount: 1, bonus: { health: 1 } }]
+  dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { health: 1 } }]
 };
 
 function randomItem(list) {

--- a/backend/src/utils/generateStats.js
+++ b/backend/src/utils/generateStats.js
@@ -28,34 +28,13 @@ const raceModifiers = {
     male: { strength: 2, charisma: 1 },
     female: { strength: 2, charisma: 1 },
   },
-  halfling: {
-    male: { agility: 2, charisma: 1 },
-    female: { agility: 2, charisma: 1 },
-  },
-  demon: {
-    male: { intellect: 2, charisma: 1 },
-    female: { intellect: 2, charisma: 1 },
-  },
-  beastkin: {
-    male: { agility: 2, health: 1 },
-    female: { agility: 2, health: 1 },
-  },
-  angel: {
-    male: { charisma: 2, intellect: 1 },
-    female: { charisma: 2, intellect: 1 },
-  },
-  lizardman: {
-    male: { strength: 2, health: 1 },
-    female: { strength: 2, health: 1 },
-  },
 };
 
 const classModifiers = {
   warrior: { strength: 2, defense: 1 },
   mage: { intellect: 2, charisma: 1 },
-  rogue: { agility: 2, intellect: 1 },
   healer: { charisma: 2, health: 1 },
-  ranger: { agility: 1, strength: 1 },
+  archer: { agility: 1, strength: 1 },
   bard: { charisma: 2, agility: 1 },
   paladin: { strength: 2, charisma: 2 },
 };

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -153,7 +153,7 @@ describe('Character Controller - create', () => {
 
   it('uses provided raceId and professionId', async () => {
     Race.findById.mockResolvedValue({ _id: 'r2', name: 'Orc', code: 'orc' });
-    Profession.findById.mockResolvedValue({ _id: 'p2', name: 'Rogue', code: 'rogue' });
+    Profession.findById.mockResolvedValue({ _id: 'p2', name: 'Archer', code: 'archer' });
 
     let saved;
     Character.mockImplementation(data => {

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -22,7 +22,7 @@ describe('generateInventory', () => {
       { item: 'Меч', amount: 1, bonus: {} },
       { item: 'Шкіряна броня', amount: 1, bonus: {} },
       { item: 'Зілля здоров’я', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }
+      { item: 'Кістяний талісман', amount: 1, bonus: { strength: 1 } }
     ]);
   });
 
@@ -37,7 +37,7 @@ describe('generateInventory', () => {
       { item: 'Сокира', amount: 1, bonus: {} },
       { item: 'Щит', amount: 1, bonus: {} },
       { item: 'Зілля здоров’я', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', amount: 1, bonus: { STR: 1 } }
+      { item: 'Кістяний талісман', amount: 1, bonus: { strength: 1 } }
     ]);
   });
 

--- a/backend/tests/generateStats.test.js
+++ b/backend/tests/generateStats.test.js
@@ -1,0 +1,17 @@
+const generateStats = require('../src/utils/generateStats');
+
+describe('generateStats', () => {
+  it('applies race and class bonuses', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const stats = generateStats('orc', 'warrior', 'male');
+    Math.random.mockRestore();
+    expect(stats).toEqual({
+      health: 6,
+      defense: 6,
+      strength: 9,
+      intellect: 5,
+      agility: 5,
+      charisma: 5
+    });
+  });
+});

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -24,7 +24,7 @@ describe('seed script', () => {
   });
 
   it('creates starting sets for each class', async () => {
-    const codes = ['warrior','mage','rogue','healer','ranger','bard','paladin'];
+    const codes = ['warrior','mage','archer','paladin','bard','healer'];
     for (const code of codes) {
       const count = await StartingSet.countDocuments({ classCode: code });
       expect(count).toBeGreaterThan(0);

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5,17 +5,6 @@
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",
   "races": {
-    "human": "Human",
-    "elf": "Elf",
-    "orc": "Orc",
-    "gnome": "Gnome",
-    "dwarf": "Dwarf",
-    "halfling": "Halfling",
-    "demon": "Demon",
-    "beastkin": "Beastkin",
-    "angel": "Angel",
-    "lizardman": "Lizardman",
-
     "human_male": "Human (male)",
     "human_female": "Human (female)",
     "elf_male": "Elf (male)",
@@ -25,32 +14,15 @@
     "gnome_male": "Gnome (male)",
     "gnome_female": "Gnome (female)",
     "dwarf_male": "Dwarf (male)",
-    "dwarf_female": "Dwarf (female)",
-    "halfling_male": "Halfling (male)",
-    "halfling_female": "Halfling (female)",
-    "demon_male": "Demon (male)",
-    "demon_female": "Demon (female)",
-    "beastkin_male": "Beastkin (male)",
-    "beastkin_female": "Beastkin (female)",
-    "angel_male": "Angel (male)",
-    "angel_female": "Angel (female)",
-    "lizardman_male": "Lizardman (male)",
-    "lizardman_female": "Lizardman (female)"
- main
+    "dwarf_female": "Dwarf (female)"
   },
   "classes": {
     "warrior": "Warrior",
     "mage": "Mage",
-    "rogue": "Rogue",
-    "healer": "Healer",
-    "ranger": "Ranger",
-    "bard": "Bard",
+    "archer": "Archer",
     "paladin": "Paladin",
-    "wizard": "Wizard",
-    "cleric": "Cleric",
-    "druid": "Druid",
-    "monk": "Monk",
-    "barbarian": "Barbarian"
+    "bard": "Bard",
+    "healer": "Healer"
   },
   "stats": {
     "health": "Health",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -5,17 +5,6 @@
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",
   "races": {
-    "human": "Людина",
-    "elf": "Ельф",
-    "orc": "Орк",
-    "gnome": "Гном",
-    "dwarf": "Дварф",
-    "halfling": "Хафлінг",
-    "demon": "Демон",
-    "beastkin": "Звіролюдина",
-    "angel": "Ангел",
-    "lizardman": "Ящіролюд",
-
     "human_male": "Людина (чоловік)",
     "human_female": "Людина (жінка)",
     "elf_male": "Ельф (чоловік)",
@@ -25,32 +14,15 @@
     "gnome_male": "Гном (чоловік)",
     "gnome_female": "Гном (жінка)",
     "dwarf_male": "Дварф (чоловік)",
-    "dwarf_female": "Дварф (жінка)",
-    "halfling_male": "Хафлінг (чоловік)",
-    "halfling_female": "Хафлінг (жінка)",
-    "demon_male": "Демон (чоловік)",
-    "demon_female": "Демон (жінка)",
-    "beastkin_male": "Звіролюдина (чоловік)",
-    "beastkin_female": "Звіролюдина (жінка)",
-    "angel_male": "Ангел (чоловік)",
-    "angel_female": "Ангел (жінка)",
-    "lizardman_male": "Ящіролюд (чоловік)",
-    "lizardman_female": "Ящіролюд (жінка)"
- main
+    "dwarf_female": "Дварф (жінка)"
   },
   "classes": {
     "warrior": "Воїн",
     "mage": "Маг",
-    "rogue": "Розбійник",
-    "healer": "Лікар",
-    "ranger": "Рейнджер",
-    "bard": "Бард",
+    "archer": "Лучник",
     "paladin": "Паладин",
-    "wizard": "Чарівник",
-    "cleric": "Клерик",
-    "druid": "Друїд",
-    "monk": "Монах",
-    "barbarian": "Варвар"
+    "bard": "Бард",
+    "healer": "Лікар"
   },
   "stats": {
     "health": "Здоров'я",

--- a/frontend/src/utils/characterUtils.js
+++ b/frontend/src/utils/characterUtils.js
@@ -1,23 +1,22 @@
 export const races = [
-  'Human',
-  'Elf',
-  'Orc',
-  'Gnome',
-  'Dwarf',
-  'Halfling',
-  'Demon',
-  'Beastkin',
-  'Angel',
-  'Lizardman'
+  'Human (male)',
+  'Human (female)',
+  'Elf (male)',
+  'Elf (female)',
+  'Orc (male)',
+  'Orc (female)',
+  'Gnome (male)',
+  'Gnome (female)',
+  'Dwarf (male)',
+  'Dwarf (female)'
 ];
 export const classes = [
   'Warrior',
   'Mage',
-  'Rogue',
-  'Healer',
-  'Ranger',
+  'Archer',
+  'Paladin',
   'Bard',
-  'Paladin'
+  'Healer'
 ];
 
 


### PR DESCRIPTION
## Summary
- seed gendered races and new classes
- generate new starting stats and inventories
- update frontend locale tables
- adjust utils and tests for new data

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_684e977dc1388322b6ded9d4ef60407c