### PR TITLE
Fix translation hook on character creation page

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -2,9 +2,11 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LogoutButton from "../components/LogoutButton";
 import { createCharacter, getRaces, getProfessions } from '../utils/api';
+import { useTranslation } from 'react-i18next';
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [form, setForm] = useState({ name: '', race: '', profession: '' });
   const [image, setImage] = useState(null);
   const [error, setError] = useState(null);


### PR DESCRIPTION
## Summary
- import `useTranslation` in `CharacterCreatePage`
- initialize `t` for translations

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684e9b9eb5e08322be46457fc84e923e