### PR TITLE
Fix race/class display and remove manual selection

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -23,11 +23,11 @@ export default function CharacterCard({
       <h3 className="text-xl text-dndgold text-center font-dnd mb-2">{character.name}</h3>
       <div className="text-base">
         <strong className="text-dndgold">Раса:</strong>{' '}
-        {t('races.' + (character.race?.code || '')) || character.race?.name || '—'}
+        {character.race?.code ? t(`races.${character.race.code}`) : (character.race?.name || '—')}
       </div>
       <div className="text-base">
         <strong className="text-dndgold">Клас:</strong>{' '}
-        {t('classes.' + (character.profession?.code || '')) || character.profession?.name || '—'}
+        {character.profession?.code ? t(`classes.${character.profession.code}`) : (character.profession?.name || '—')}
       </div>
 
       <div className="text-sm">

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -13,8 +13,8 @@ export default function PlayerCard({ character, onSelect }) {
       />
       <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
       <p className="text-xs text-center">
-        {t('races.' + (character.race?.code || '')) || character.race?.name} /{' '}
-        {t('classes.' + (character.profession?.code || '')) || character.profession?.name}
+        {character.race?.code ? t(`races.${character.race.code}`) : (character.race?.name || '')} /{' '}
+        {character.profession?.code ? t(`classes.${character.profession.code}`) : (character.profession?.name || '')}
       </p>
       {character.stats && (
         <ul className="text-xs grid grid-cols-2 gap-x-2 mt-2">

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,22 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LogoutButton from "../components/LogoutButton";
-import { createCharacter, getRaces, getProfessions } from '../utils/api';
+import { createCharacter } from '../utils/api';
 import { useTranslation } from 'react-i18next';
 
 export default function CharacterCreatePage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const [form, setForm] = useState({ name: '', race: '', profession: '' });
+  const [form, setForm] = useState({ name: '' });
   const [image, setImage] = useState(null);
   const [error, setError] = useState(null);
-  const [races, setRaces] = useState([]);
-  const [professions, setProfessions] = useState([]);
 
-  useEffect(() => {
-    getRaces().then(setRaces).catch(() => {});
-    getProfessions().then(setProfessions).catch(() => {});
-  }, []);
 
   const handleChange = (e) => {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
@@ -29,11 +23,9 @@ export default function CharacterCreatePage() {
         setError("Будь ласка, заповніть ім'я персонажа.");
         return;
       }
-      const payload = {
-        name: form.name,
-        raceId: form.race,
-        professionId: form.profession,
-      };
+        const payload = {
+          name: form.name,
+        };
       if (image) payload.image = image;
       await createCharacter(payload);
       navigate('/profile');
@@ -67,34 +59,7 @@ export default function CharacterCreatePage() {
           onChange={handleChange}
           className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
         />
-        <label className="block text-sm mb-1">Раса</label>
-        <select
-          name="race"
-          value={form.race}
-          onChange={handleChange}
-          className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
-        >
-          <option value="">Оберіть расу</option>
-          {races.map((r) => (
-            <option key={r._id || r.id || r.code} value={r._id || r.id}>
-              {t('races.' + (r.code || '')) || r.name}
-            </option>
-          ))}
-        </select>
-        <label className="block text-sm mb-1">Клас</label>
-        <select
-          name="profession"
-          value={form.profession}
-          onChange={handleChange}
-          className="w-full mb-4 px-3 py-2 rounded bg-[#2d1a10] border border-dndgold text-white"
-        >
-          <option value="">Оберіть клас</option>
-          {professions.map((p) => (
-            <option key={p._id || p.id || p.code} value={p._id || p.id}>
-              {t('classes.' + (p.code || '')) || p.name}
-            </option>
-          ))}
-        </select>
+
         <label className="block text-sm mb-1">Зображення</label>
         <input
           type="file"

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -21,10 +21,10 @@ export default function CharacterListPage() {
             <h2 className="text-xl text-dndgold">{c.name}</h2>
             <p className="text-base italic mb-2">{c.description}</p>
             <p className="text-xs">
-              Раса: {t('races.' + (c.race?.code || '')) || c.race?.name || '—'}
+              Раса: {c.race?.code ? t(`races.${c.race.code}`) : (c.race?.name || '—')}
             </p>
             <p className="text-xs">
-              Клас: {t('classes.' + (c.profession?.code || '')) || c.profession?.name || '—'}
+              Клас: {c.profession?.code ? t(`classes.${c.profession.code}`) : (c.profession?.name || '—')}
             </p>
             <button
               onClick={() => navigate(`/lobby?char=${c._id}`)}

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -122,8 +122,8 @@ export default function LobbyPage() {
             <div>
               <div className="font-bold">{character.name}</div>
               <div className="text-sm">
-                {t('races.' + (character.race?.code || '')) || character.race?.name} &middot;{' '}
-                {t('classes.' + (character.profession?.code || '')) || character.profession?.name}
+                {character.race?.code ? t(`races.${character.race.code}`) : (character.race?.name || '')} &middot;{' '}
+                {character.profession?.code ? t(`classes.${character.profession.code}`) : (character.profession?.name || '')}
               </div>
             </div>
           </div>
@@ -140,10 +140,10 @@ export default function LobbyPage() {
                   <>
                     {pl.character.name}
                     {pl.character.race && (
-                      <> – {t('races.' + (pl.character.race?.code || '')) || pl.character.race?.name}</>
+                      <> – {pl.character.race.code ? t(`races.${pl.character.race.code}`) : (pl.character.race.name || '')}</>
                     )}
                     {pl.character.profession && (
-                      <> / {t('classes.' + (pl.character.profession?.code || '')) || pl.character.profession?.name}</>
+                      <> / {pl.character.profession.code ? t(`classes.${pl.character.profession.code}`) : (pl.character.profession.name || '')}</>
                     )}
                   </>
                 ) : (


### PR DESCRIPTION
## Summary
- remove race/class dropdowns from character creation form
- simplify character creation request payload
- translate race/class names only when codes provided to avoid fallback strings

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9f1214ec832293043795922fa991