### PR TITLE
Display inventory bonuses on Player card

### DIFF
--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -27,12 +27,22 @@ export default function PlayerCard({ character, onSelect }) {
       )}
       {character.inventory && character.inventory.length > 0 && (
         <ul className="text-xs list-disc pl-4 mt-2 space-y-0.5">
-          {character.inventory.map((it, idx) => (
-            <li key={idx}>
-              {it.item}
-              {it.amount > 1 ? ` x${it.amount}` : ''}
-            </li>
-          ))}
+          {character.inventory.map((it, idx) => {
+            const bonus = it.bonus && Object.keys(it.bonus).length
+              ? ' (' +
+                Object.entries(it.bonus)
+                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
+                  .join(', ') +
+                ')'
+              : '';
+            return (
+              <li key={idx}>
+                {it.item}
+                {it.amount > 1 ? ` x${it.amount}` : ''}
+                {bonus}
+              </li>
+            );
+          })}
         </ul>
       )}
       {onSelect && (


### PR DESCRIPTION
## Summary
- show inventory bonuses in `PlayerCard`

## Testing
- `npm test --silent` in `frontend` *(fails: jest not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eaa0b8c24832297ac1afbab90732a