### PR TITLE
Fix stat translation for item bonuses

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -68,7 +68,7 @@ export default function CharacterCard({
           {character.inventory && character.inventory.map((it, idx) => {
             const bonus = it.bonus && Object.keys(it.bonus).length
               ? ' (' + Object.entries(it.bonus)
-                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k, k)}`)
+                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
                   .join(', ') + ')'
               : '';
             return (


### PR DESCRIPTION
## Summary
- lowercase item bonus stat keys before translation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684eaa0d04d08322bb4254562f6c444e