### PR TITLE
Fix GM panel layout

### DIFF
--- a/frontend/src/components/GMPanel.jsx
+++ b/frontend/src/components/GMPanel.jsx
@@ -36,7 +36,7 @@ export default function GMPanel({ tableId, socket, players, className = '' }) {
   return (
     <div className={`bg-[#25160f]/80 rounded-2xl p-4 mb-2 mt-4 text-center ${className}`}>
       <div className="text-dndgold text-xl font-bold mb-2">GM-панель</div>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-row flex-wrap gap-2">
         {/* Додавання монстра */}
         <div className="flex flex-wrap items-center justify-center gap-2">
           <input

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -74,7 +74,7 @@ export default function GameTablePage() {
           <LogoutButton />
         </div>
       </div>
-      <div className="relative flex-1 h-[80vh] bg-[#1b110a]/80 rounded-b-2xl px-6 pb-4 overflow-hidden">
+      <div className="relative flex-1 h-[80vh] bg-[#1b110a]/80 rounded-b-2xl px-6 pb-4 md:pb-32 overflow-hidden">
         {/* Ліві слоти гравців */}
         <div className="md:absolute md:left-2 md:top-1/2 md:-translate-y-1/2 flex flex-col gap-2">
           {visiblePlayers.slice(0,3).map((p,i) => (
@@ -105,7 +105,7 @@ export default function GameTablePage() {
           {isGM ? (
             <>
               <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
-              <MusicPlayer isGM={isGM} className="w-48" />
+              <MusicPlayer isGM={isGM} className="w-32 md:w-40" />
               <GMPanel tableId={tableId} socket={socket} players={players} className="w-48" />
               <DiceBox className="self-end w-40" />
             </>


### PR DESCRIPTION
## Summary
- shrink MusicPlayer width for better spacing
- arrange GMPanel options in a horizontal row
- add extra padding so the bottom panel doesn't hide the map

## Testing
- `npm test --prefix backend -- -i`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684eba8147048322ac09350ef4906a35