### PR TITLE
Add theme toggle and updated navbar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import AdminUsersPage from './pages/admin/AdminUsersPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
 import AdminLoginPage from './pages/AdminLoginPage';
+import SettingsPanel from './pages/SettingsPanel';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
 const isAdmin = () => {
@@ -35,6 +36,7 @@ const App = () => (
     <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />
     <Route path="/admin/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/admin/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
+    <Route path="/settings" element={isAuthenticated() ? <SettingsPanel /> : <Navigate to="/login" />} />
     <Route path="/table/:tableId" element={<GameTablePage />} />
     <Route path="*" element={<Navigate to="/" />} />
   </Routes>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import LanguageSwitch from './LanguageSwitch';
+import ThemeToggle from './ThemeToggle';
 
 function Navbar() {
   const navigate = useNavigate();
@@ -14,23 +15,25 @@ function Navbar() {
   };
 
   return (
-    <nav className="bg-gray-800 text-white px-6 py-3 flex justify-between items-center">
-      <Link to="/" className="text-xl font-bold">
-        D-DUA
+    <nav className="bg-dndbg text-dndgold flex items-center px-4 py-2 shadow-md dark:bg-gray-900 dark:text-white">
+      <Link to="/" className="flex items-center mr-6">
+        <img src="/logo.png" alt="Logo" className="w-8 h-8 mr-2" />
+        <span className="font-dnd text-2xl">D-DUA</span>
       </Link>
-      <div className="flex items-center gap-4">
-        {user && <span className="text-sm"> {user.login}</span>}
+      <div className="flex items-center gap-4 flex-1">
+        <Link to="/profile" className="hover:text-white">Profile</Link>
+        <Link to="/settings" className="hover:text-white">Settings</Link>
         {token && (
-          <button
-            onClick={handleLogout}
-            className="bg-red-500 hover:bg-red-600 px-3 py-1 rounded text-sm"
-          >
-            Вийти
+          <button onClick={handleLogout} className="text-dndred hover:text-dndgold">
+            Logout
           </button>
         )}
       </div>
-    <div className='ml-auto'><LanguageSwitch /></div>
-</nav>
+      <div className="flex items-center gap-3 ml-auto">
+        <ThemeToggle />
+        <LanguageSwitch />
+      </div>
+    </nav>
   );
 }
 

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,15 @@
+import { useSettings } from '../context/SettingsContext';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useSettings();
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+  return (
+    <button
+      onClick={toggle}
+      className="text-dndgold hover:text-white transition"
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? '🌞' : '🌜'}
+    </button>
+  );
+}

--- a/frontend/src/context/SettingsContext.jsx
+++ b/frontend/src/context/SettingsContext.jsx
@@ -7,6 +7,7 @@ export function SettingsProvider({ children }) {
   const [brightness, setBrightness] = useState(1);
   const [volume, setVolume] = useState(0.5);
   const [language, setLanguage] = useState("ua");
+  const [theme, setTheme] = useState('light');
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem("settings"));
@@ -14,12 +15,20 @@ export function SettingsProvider({ children }) {
       setBrightness(stored.brightness ?? 1);
       setVolume(stored.volume ?? 0.5);
       setLanguage(stored.language ?? "ua");
+      setTheme(stored.theme ?? 'light');
     }
   }, []);
 
   useEffect(() => {
-    localStorage.setItem("settings", JSON.stringify({ brightness, volume, language }));
-  }, [brightness, volume, language]);
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({ brightness, volume, language, theme })
+    );
+  }, [brightness, volume, language, theme]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
 
   useEffect(() => {
     const save = async () => {
@@ -35,7 +44,16 @@ export function SettingsProvider({ children }) {
   }, [volume, brightness]);
 
   return (
-    <SettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, language, setLanguage }}>
+    <SettingsContext.Provider value={{
+      brightness,
+      setBrightness,
+      volume,
+      setVolume,
+      language,
+      setLanguage,
+      theme,
+      setTheme,
+    }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */;
 module.exports = {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
## Summary
- enable dark mode class in Tailwind
- persist `theme` in `SettingsContext` and update `<html>` accordingly
- add `ThemeToggle` component
- redesign `Navbar` with logo, profile/settings links, and theme toggle
- route `/settings` now renders `SettingsPanel`

## Testing
- `./setup.sh`
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68567ca686b88322902e9de366645751