### PR TITLE
Add player card modal with animation

### DIFF
--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,0 +1,27 @@
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function Modal({ open, onClose, children }) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <motion.div
+            className="bg-[#1c120a] border border-dndgold rounded-xl p-4 max-h-[90vh] overflow-y-auto"
+            initial={{ scale: 0.9 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0.9 }}
+            onClick={e => e.stopPropagation()}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -1,58 +1,88 @@
-
+import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { withApiHost } from '../utils/imageUtils';
 import { useTranslation } from 'react-i18next';
+import { getClassBorderColor } from '../utils/classColors';
+import Modal from './Modal';
 
 export default function PlayerCard({ character, onSelect }) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const borderColor = getClassBorderColor(
+    character.profession?.code || character.profession?.name
+  );
+
   return (
-    <div className="border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd w-56">
-      <img
-        src={withApiHost(character.image) || '/default-avatar.png'}
-        alt="character"
-        className="rounded mb-2 h-28 w-full object-cover"
-      />
-      <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
-      <p className="text-xs text-center">
-        {character.race?.code ? t(`races.${character.race.code.toLowerCase()}`, character.race.name || character.race.code) : (character.race?.name || '')} /{' '}
-        {character.profession?.code ? t(`classes.${character.profession.code.toLowerCase()}`, character.profession.name || character.profession.code) : (character.profession?.name || '')}
-      </p>
-      {character.stats && (
-        <ul className="text-xs grid grid-cols-2 gap-x-2 mt-2">
-          {Object.entries(character.stats).map(([key, val]) => (
-            <li key={key}>
-              {t('stats.' + key) || key}: {val}
-            </li>
-          ))}
-        </ul>
-      )}
-      {character.inventory && character.inventory.length > 0 && (
-        <ul className="text-xs list-disc pl-4 mt-2 space-y-0.5">
-          {character.inventory.map((it, idx) => {
-            const bonus = it.bonus && Object.keys(it.bonus).length
-              ? ' (' +
-                Object.entries(it.bonus)
-                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
-                  .join(', ') +
-                ')'
-              : '';
-            return (
-              <li key={idx}>
-                {it.item}
-                {it.amount > 1 ? ` x${it.amount}` : ''}
-                {bonus}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-      {onSelect && (
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className={`border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd w-56 ${borderColor}`}
+      >
+        <img
+          src={withApiHost(character.image) || '/default-avatar.png'}
+          alt="character"
+          className="rounded mb-2 h-28 w-full object-cover"
+          onError={e => (e.currentTarget.src = '/default-avatar.png')}
+        />
+        <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
+        <p className="text-xs text-center">
+          {character.race?.code
+            ? t(`races.${character.race.code.toLowerCase()}`, character.race.name || character.race.code)
+            : character.race?.name || ''}{' '}/{' '}
+          {character.profession?.code
+            ? t(`classes.${character.profession.code.toLowerCase()}`, character.profession.name || character.profession.code)
+            : character.profession?.name || ''}
+        </p>
         <button
-          onClick={() => onSelect(character)}
-          className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700"
+          onClick={() => setOpen(true)}
+          className="mt-2 bg-dndgold text-dndred font-dnd rounded-2xl px-3 py-1"
         >
-          Грати
+          Детальніше
         </button>
-      )}
-    </div>
+        {onSelect && (
+          <button
+            onClick={() => onSelect(character)}
+            className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700"
+          >
+            Грати
+          </button>
+        )}
+      </motion.div>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <h3 className="text-lg text-dndgold text-center mb-2">{character.name}</h3>
+        {character.stats && (
+          <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
+            {Object.entries(character.stats).map(([key, val]) => (
+              <li key={key}>
+                {t('stats.' + key) || key}: {val}
+              </li>
+            ))}
+          </ul>
+        )}
+        {character.inventory && character.inventory.length > 0 && (
+          <ul className="list-disc pl-4 mt-2 space-y-0.5">
+            {character.inventory.map((it, idx) => {
+              const bonus =
+                it.bonus && Object.keys(it.bonus).length
+                  ?
+                      ' (' +
+                      Object.entries(it.bonus)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
+                        .join(', ') +
+                      ')'
+                  : '';
+              return (
+                <li key={idx}>
+                  {it.item}
+                  {it.amount > 1 ? ` x${it.amount}` : ''}
+                  {bonus}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -1,0 +1,14 @@
+export function getClassBorderColor(profession) {
+  const map = {
+    warrior: 'border-red-600',
+    mage: 'border-blue-600',
+    archer: 'border-green-600',
+    paladin: 'border-yellow-600',
+    bard: 'border-purple-600',
+    healer: 'border-teal-600',
+    druid: 'border-green-700',
+  };
+  if (!profession) return 'border-dndgold';
+  const key = profession.toLowerCase();
+  return map[key] || 'border-dndgold';
+}


### PR DESCRIPTION
## Summary
- map professions to border colors
- show PlayerCard avatar with default fallback
- animate PlayerCard and open details modal
- provide generic Modal component

## Testing
- `npm test` in `frontend`
- `npm test` in `backend` *(fails: socket.startGame.test.js timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68567ca794dc832289aa5c987fbec399