### PR TITLE
Enhance chat UI with parsed text, GM style and animation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^11.0.0",
         "i18next": "^23.0.1",
         "lucide-react": "^0.346.0",
+        "marked": "^9.1.6",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
@@ -4815,6 +4816,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,29 +12,30 @@
   },
   "dependencies": {
     "axios": "^1.6.0",
+    "chart.js": "^4.4.9",
     "clsx": "^2.1.0",
     "framer-motion": "^11.0.0",
+    "i18next": "^23.0.1",
     "lucide-react": "^0.346.0",
+    "marked": "^9.1.6",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^13.0.0",
+    "react-player": "^2.12.0",
     "react-router-dom": "^6.30.1",
     "socket.io-client": "^4.7.5",
-    "zustand": "^4.5.2",
-    "react-player": "^2.12.0",
-    "i18next": "^23.0.1",
-    "react-i18next": "^13.0.0",
-    "react-chartjs-2": "^5.3.0",
-    "chart.js": "^4.4.9"
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.19",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.24",
-    "tailwindcss": "^3.4.1",
-    "vite": "^5.2.8",
     "jest": "^29.7.0",
-    "socket.io": "^4.8.1"
+    "postcss": "^8.4.24",
+    "socket.io": "^4.8.1",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.2.8"
   }
 }

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,6 +1,9 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { io } from 'socket.io-client';
+import { marked } from 'marked';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useUserStore } from '../store/user';
 
 let socket;
 
@@ -32,11 +35,20 @@ export default function ChatBox({ sessionId }) {
   return (
     <div className="bg-[#1a110a]/90 rounded-2xl shadow-dnd p-4 max-w-md w-full mx-auto mt-3">
       <div className="h-44 overflow-y-auto mb-3 bg-[#22140d]/70 rounded-xl p-2 text-dndgold/90 text-sm">
-          {messages.map((msg, i) => (
-            <div key={i} className="mb-1">
-              <span className="font-dnd text-dndgold/80">{msg.user || 'Гість'}:</span> {msg.text}
-            </div>
-          ))}
+          <AnimatePresence initial={false}>
+            {messages.map((msg, i) => (
+              <motion.div
+                key={i}
+                initial={{ opacity: 0, y: 5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                className={`mb-1 ${msg.userRole === 'gm' ? 'bg-dndred/30 text-dndgold px-1 rounded' : ''}`}
+              >
+                <span className="font-dnd text-dndgold/80">{msg.user || 'Гість'}:</span>{' '}
+                <span dangerouslySetInnerHTML={{ __html: marked.parse(msg.text || '') }} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
         <div ref={chatEnd} />
       </div>
       <form className="flex gap-2" onSubmit={send}>

--- a/frontend/src/components/ChatComponent.jsx
+++ b/frontend/src/components/ChatComponent.jsx
@@ -1,5 +1,7 @@
 
 import { useState, useEffect, useRef } from 'react';
+import { marked } from 'marked';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export default function ChatComponent({ tableId, user, messages, socket }) {
   const [input, setInput] = useState("");
@@ -21,9 +23,20 @@ export default function ChatComponent({ tableId, user, messages, socket }) {
     <div className="border border-dndgold rounded-2xl p-2 bg-[#25160f]/80 w-60">
       <div className="flex flex-col h-full">
         <div className="flex-1 max-h-32 overflow-y-auto bg-[#20100a]/70 p-2 rounded-xl mb-2">
-          {messages.map((m, i) => (
-            <div key={i}><b>{m.user}:</b> {m.text}</div>
-          ))}
+          <AnimatePresence initial={false}>
+            {messages.map((m, i) => (
+              <motion.div
+                key={i}
+                initial={{ opacity: 0, y: 5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                className={`mb-1 ${m.userRole === 'gm' ? 'bg-dndred/30 text-dndgold px-1 rounded' : ''}`}
+              >
+                <b>{m.user}:</b>{' '}
+                <span dangerouslySetInnerHTML={{ __html: marked.parse(m.text || '') }} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
           <div ref={chatEnd} />
         </div>
         <form onSubmit={send}>


### PR DESCRIPTION
## Summary
- use `marked` to parse chat text
- highlight GM messages in chat
- animate chat entries with framer-motion
- add missing import in `ChatBox`

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68567caa15a08322a881d335f889e763