### PR TITLE
Update theme fonts and colors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,7 +1,3 @@
 body {
-  background-image: url('/nd-bg.png');
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
-  font-family: 'IM Fell English SC', serif !important;
+  @apply bg-brown-900 text-amber-100 font-cinzel;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&family=Cinzel&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel&family=Uncial+Antiqua&family=MedievalSharp&family=IM+Fell+English+SC&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -6,10 +6,14 @@
 body {
   font-family: 'Cinzel', serif;
   font-size: 18px;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/map-bg.jpg');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
 }
 
 .font-dnd {
-  font-family: 'IM Fell English SC', serif;
+  font-family: 'Uncial Antiqua', 'MedievalSharp', 'IM Fell English SC', serif;
 }
 
 @layer utilities {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,8 @@
-/** @type {import('tailwindcss').Config} */;
+const colors = require('tailwindcss/colors');
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",
@@ -7,12 +10,28 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        amber: colors.amber,
+        brown: {
+          50: '#efebe9',
+          100: '#d7ccc8',
+          200: '#bcaaa4',
+          300: '#a1887f',
+          400: '#8d6e63',
+          500: '#795548',
+          600: '#6d4c41',
+          700: '#5d4037',
+          800: '#4e342e',
+          900: '#3e2723',
+        },
         dndgold: '#FFD700',
         dndred: '#8B0000',
         dndbg: '#322018',
       },
       fontFamily: {
         dnd: ['"IM Fell English SC"', 'serif'],
+        cinzel: ['"Cinzel"', 'serif'],
+        'uncial-antiqua': ['"Uncial Antiqua"', 'cursive'],
+        medieval: ['"MedievalSharp"', 'cursive'],
       },
       boxShadow: {
         dnd: '0 0 10px rgba(0, 0, 0, 0.7), 0 0 0 2px #FFD700',


### PR DESCRIPTION
## Summary
- add amber/brown palette with dark mode to Tailwind config
- import Google fonts and improve base styles
- use the new colors/fonts in App.css

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68567cac18b88322a4d42d541af2eb8d