### PR TITLE
Add settings route and navbar link

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import AdminUsersPage from './pages/admin/AdminUsersPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
 import AdminLoginPage from './pages/AdminLoginPage';
+import SettingsPanel from './pages/SettingsPanel';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
 const isAdmin = () => {
@@ -35,6 +36,7 @@ const App = () => (
     <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />
     <Route path="/admin/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/admin/login" />} />
     <Route path="/change-password" element={isAuthenticated() ? <ChangePasswordPage /> : <Navigate to="/login" />} />
+    <Route path="/settings" element={<SettingsPanel />} />
     <Route path="/table/:tableId" element={<GameTablePage />} />
     <Route path="*" element={<Navigate to="/" />} />
   </Routes>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -28,6 +28,9 @@ function Navbar() {
             Вийти
           </button>
         )}
+        <Link to="/settings" className="text-sm hover:underline">
+          ⚙️
+        </Link>
       </div>
     <div className='ml-auto'><LanguageSwitch /></div>
 </nav>


### PR DESCRIPTION
## Summary
- expose `SettingsPanel` at `/settings`
- link to settings from the navigation bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567cad3c3083228d35600e793a22c2