### PR TITLE
Add Ukrainian dictionaries

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -1,7 +1,13 @@
 
 import { withApiHost } from '../utils/imageUtils';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { raceUA, classUA, statUA } from '../translations/ua';
+
+function translateEffect(effectString) {
+  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
+    return `+${num} до ${statUA[stat] || stat}`;
+  });
+}
 
 export default function CharacterCard({
   character,
@@ -11,7 +17,6 @@ export default function CharacterCard({
   editLabel = 'Редагувати',
   deleteLabel = 'Видалити',
 }) {
-  const { t } = useTranslation();
   const [desc, setDesc] = useState(character.description || '');
   return (
     <div className="bg-[#1c120a]/80 text-white border border-dndgold rounded-xl shadow-lg p-4 space-y-2">
@@ -23,11 +28,11 @@ export default function CharacterCard({
       <h3 className="text-xl text-dndgold text-center font-dnd mb-2">{character.name}</h3>
       <div className="text-base">
         <strong className="text-dndgold">Раса:</strong>{' '}
-        {character.race?.code ? t(`races.${character.race.code.toLowerCase()}`, character.race.name || character.race.code) : (character.race?.name || '—')}
+        {raceUA[character.race?.code || character.race] || character.race?.name || character.race?.code || '—'}
       </div>
       <div className="text-base">
         <strong className="text-dndgold">Клас:</strong>{' '}
-        {character.profession?.code ? t(`classes.${character.profession.code.toLowerCase()}`, character.profession.name || character.profession.code) : (character.profession?.name || '—')}
+        {classUA[character.profession?.code || character.profession] || character.profession?.name || character.profession?.code || '—'}
       </div>
 
       <div className="text-sm">
@@ -56,7 +61,7 @@ export default function CharacterCard({
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
             {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {t('stats.' + key) || key}: {val}
+                {statUA[key.toUpperCase()] || key}: {val}
               </li>
             ))}
           </ul>
@@ -67,13 +72,16 @@ export default function CharacterCard({
         <ul className="list-none pl-0 text-base space-y-0.5">
           {character.inventory && character.inventory.map((it, idx) => {
             const bonus = it.bonus && Object.keys(it.bonus).length
-              ? ' (' + Object.entries(it.bonus)
-                  .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
-                  .join(', ') + ')'
+              ? ' (' +
+                  Object.entries(it.bonus)
+                    .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${statUA[k.toUpperCase()] || k}`)
+                    .join(', ') +
+                  ')'
               : '';
             return (
               <li key={idx}>
                 {it.item} {it.amount > 1 ? `x${it.amount}` : ''}{bonus}
+                {it.effect ? ` (${translateEffect(it.effect)})` : ''}
               </li>
             );
           })}

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -1,4 +1,12 @@
 
+import { statUA } from '../translations/ua';
+
+function translateEffect(effectString) {
+  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
+    return `+${num} до ${statUA[stat] || stat}`;
+  });
+}
+
 export default function InventoryList({ items, filter = 'all' }) {
   if (!items || !items.length) return null;
 
@@ -20,6 +28,7 @@ export default function InventoryList({ items, filter = 'all' }) {
           <li key={i} className="text-dndgold">
             {item.item || item.name || item}
             {item.amount ? `x${item.amount}` : ''}
+            {item.effect ? ` (${translateEffect(item.effect)})` : ''}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { withApiHost } from '../utils/imageUtils';
-import { useTranslation } from 'react-i18next';
+import { raceUA, classUA, statUA } from '../translations/ua';
 import { getClassBorderColor } from '../utils/classColors';
 import Modal from './Modal';
 
+function translateEffect(effectString) {
+  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
+    return `+${num} до ${statUA[stat] || stat}`;
+  });
+}
+
 export default function PlayerCard({ character, onSelect }) {
-  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const borderColor = getClassBorderColor(
     character.profession?.code || character.profession?.name
@@ -27,12 +32,8 @@ export default function PlayerCard({ character, onSelect }) {
         />
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
-          {character.race?.code
-            ? t(`races.${character.race.code.toLowerCase()}`, character.race.name || character.race.code)
-            : character.race?.name || ''}{' '}/{' '}
-          {character.profession?.code
-            ? t(`classes.${character.profession.code.toLowerCase()}`, character.profession.name || character.profession.code)
-            : character.profession?.name || ''}
+          {raceUA[character.race?.code || character.race] || character.race?.name || character.race?.code || ''}{' '}/{' '}
+          {classUA[character.profession?.code || character.profession] || character.profession?.name || character.profession?.code || ''}
         </p>
         <button
           onClick={() => setOpen(true)}
@@ -55,7 +56,7 @@ export default function PlayerCard({ character, onSelect }) {
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
             {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {t('stats.' + key) || key}: {val}
+                {statUA[key.toUpperCase()] || key}: {val}
               </li>
             ))}
           </ul>
@@ -68,7 +69,7 @@ export default function PlayerCard({ character, onSelect }) {
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${statUA[k.toUpperCase()] || k}`)
                         .join(', ') +
                       ')'
                   : '';
@@ -77,6 +78,7 @@ export default function PlayerCard({ character, onSelect }) {
                   {it.item}
                   {it.amount > 1 ? ` x${it.amount}` : ''}
                   {bonus}
+                  {it.effect ? ` (${translateEffect(it.effect)})` : ''}
                 </li>
               );
             })}

--- a/frontend/src/translations/ua.js
+++ b/frontend/src/translations/ua.js
@@ -1,0 +1,25 @@
+export const raceUA = {
+  Lizardman: "Ящеролюд",
+  Human: "Людина",
+  Elf: "Ельф",
+  Dwarf: "Дворф",
+  Orc: "Орк",
+};
+
+export const classUA = {
+  Paladin: "Паладин",
+  Rogue: "Шпигун",
+  Warrior: "Воїн",
+  Wizard: "Маг",
+  Druid: "Друїд",
+};
+
+export const statUA = {
+  STR: "Сила",
+  DEX: "Спритність",
+  INT: "Інтелект",
+  CHA: "Харизма",
+  CON: "Витривалість",
+  HP: "Здоров'я",
+  DEF: "Захист",
+};


### PR DESCRIPTION
## Summary
- add Ukrainian translation dictionaries for race, class and stat names
- show localized race, class and stat labels in character and player cards
- display item effect bonuses in Ukrainian

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856842d8330832296c52e7a12edac03