### PR TITLE
Add GM role and basic dashboard

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -12,7 +12,7 @@ exports.getUsers = async (req, res) => {
 exports.updateUserRole = async (req, res) => {
   try {
     const { role } = req.body;
-    if (!['player', 'master', 'admin'].includes(role)) {
+    if (!['player', 'gm', 'admin'].includes(role)) {
       return res.status(400).json({ message: 'Invalid role' });
     }
     const user = await User.findByIdAndUpdate(

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -21,11 +21,15 @@ exports.register = async (req, res) => {
     }
 
     const hash = await bcrypt.hash(password, 10);
+    let finalRole = 'player';
+    if (['gm', 'admin'].includes(role)) {
+      finalRole = role;
+    }
     const user = new User({
       login,
       password: hash,
       username: finalUsername,
-      role: role === 'master' ? 'master' : 'player',
+      role: finalRole,
     });
     await user.save();
 

--- a/backend/src/controllers/inventoryController.js
+++ b/backend/src/controllers/inventoryController.js
@@ -15,7 +15,7 @@ exports.update = async (req, res) => {
     const { items } = req.body;
     const characterId = req.params.characterId;
 
-    if (req.user.role !== 'admin' && req.user.role !== 'master') {
+    if (req.user.role !== 'admin' && req.user.role !== 'gm') {
       const char = await Character.findOne({ _id: characterId, user: req.user.id });
       if (!char) {
         return res.status(403).json({ message: 'Forbidden' });

--- a/backend/src/controllers/rollController.js
+++ b/backend/src/controllers/rollController.js
@@ -39,8 +39,8 @@ exports.history = async (req, res) => {
   try {
     const { session } = req.query;
     const query = { session };
-    // Майстер бачить всі, інші тільки публічні
-    if (req.user.role !== 'master') query.isPrivate = false;
+    // ГМ бачить всі, інші тільки публічні
+    if (req.user.role !== 'gm') query.isPrivate = false;
     const rolls = await Roll.find(query).sort({ createdAt: -1 }).limit(50);
     res.json(rolls);
   } catch (err) {

--- a/backend/src/middlewares/onlyMaster.js
+++ b/backend/src/middlewares/onlyMaster.js
@@ -1,5 +1,5 @@
 function onlyMaster(req, res, next) {
-  if (req.user && (req.user.role === 'master' || req.user.role === 'admin')) {
+  if (req.user && (req.user.role === 'gm' || req.user.role === 'admin')) {
     return next();
   }
   return res.status(403).json({ message: 'Forbidden' });

--- a/backend/src/models/Session.js
+++ b/backend/src/models/Session.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 
 const sessionSchema = new mongoose.Schema({
   name: { type: String, required: true },
-  master: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  gm: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   players: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   activeMap: { type: mongoose.Schema.Types.ObjectId, ref: 'Map' },
   activeMusic: { type: mongoose.Schema.Types.ObjectId, ref: 'Music' },

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -5,7 +5,11 @@ const UserSchema = new mongoose.Schema(
     login: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     username: { type: String, required: true },
-    role: { type: String, default: "player" },
+    role: {
+      type: String,
+      enum: ["player", "gm", "admin"],
+      default: "player",
+    },
     settings: {
       volume: { type: Number, default: 50 },
       brightness: { type: Number, default: 50 },

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -53,7 +53,7 @@ function init(httpServer) {
             .lean();
         }
       }
-      if (user.role === 'master' || !sess.gm) {
+      if (user.role === 'gm' || !sess.gm) {
         sess.gm = user._id;
         socket.emit('gm-assigned');
       }

--- a/backend/tests/socket.startGame.test.js
+++ b/backend/tests/socket.startGame.test.js
@@ -23,7 +23,7 @@ afterAll((done) => {
 test('start-game notifies all lobby members', (done) => {
   const url = `http://localhost:${addr.port}`;
   const tableId = 'room1';
-  const gm = { _id: 'u1', username: 'GM', role: 'master' };
+  const gm = { _id: 'u1', username: 'GM', role: 'gm' };
   const player = { _id: 'u2', username: 'P1', role: 'player' };
 
   const c1 = Client(url);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,8 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.19",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.2.1",
@@ -36,6 +38,13 @@
         "tailwindcss": "^3.4.1",
         "vite": "^5.2.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1848,6 +1857,170 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2142,6 +2315,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/asynckit": {
@@ -2845,6 +3028,13 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2915,6 +3105,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2948,6 +3148,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3746,6 +3954,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4786,6 +5004,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4815,6 +5040,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -4943,6 +5179,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5788,6 +6034,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -6346,6 +6606,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,9 +19,7 @@
     "lucide-react": "^0.346.0",
     "marked": "^9.1.6",
     "react": "^18.2.0",
-
     "react-beautiful-dnd": "^13.1.1",
-
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^13.0.0",
@@ -31,6 +29,8 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.19",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ import ChangePasswordPage from './pages/ChangePasswordPage';
 import GameTablePage from './pages/GameTablePage';
 import AdminLoginPage from './pages/AdminLoginPage';
 import SettingsPanel from './pages/SettingsPanel';
+import GMDashboard from './pages/GMDashboard';
+import GMControlPanel from './pages/GMControlPanel';
 
 const isAuthenticated = () => !!localStorage.getItem('token');
 const isAdmin = () => {
@@ -32,6 +34,9 @@ const App = () => (
     <Route path="/profile" element={isAuthenticated() ? <ProfilePage /> : <Navigate to="/login" />} />
     <Route path="/create-character" element={isAuthenticated() ? <CharacterCreatePage /> : <Navigate to="/login" />} />
     <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
+    <Route path="/gm-dashboard" element={isAuthenticated() ? <GMDashboard /> : <Navigate to="/login" />} />
+    <Route path="/gm-table/:id" element={isAuthenticated() ? <GameTablePage /> : <Navigate to="/login" />} />
+    <Route path="/gm-control/:id" element={isAuthenticated() ? <GMControlPanel /> : <Navigate to="/login" />} />
     <Route path="/admin" element={isAdmin() ? <AdminPage /> : <Navigate to="/admin/login" />} />
     <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />
     <Route path="/admin/users" element={isAdmin() ? <AdminUsersPage /> : <Navigate to="/admin/login" />} />

--- a/frontend/src/pages/GMControlPanel.jsx
+++ b/frontend/src/pages/GMControlPanel.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export default function GMControlPanel() {
+  const { id } = useParams();
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-dndbg text-dndgold font-dnd">
+      <h1 className="text-3xl">GM Control Panel for table {id}</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/GMDashboard.jsx
+++ b/frontend/src/pages/GMDashboard.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function GMDashboard() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-dndbg text-dndgold font-dnd">
+      <h1 className="text-3xl">GM Dashboard Placeholder</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -43,7 +43,7 @@ export default function GameTablePage() {
     return () => socket.disconnect();
   }, [tableId, user, characterId]);
 
-  const isGM = (user?.role === 'master') || (gm && user && gm.toString() === user._id);
+  const isGM = (user?.role === 'gm') || (gm && user && gm.toString() === user._id);
 
 
   return (

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -19,7 +19,7 @@ export default function LobbyPage() {
   const [players, setPlayers] = useState([]);
   const [gm, setGm] = useState(null);
   const [character, setCharacter] = useState(null);
-  const [isGM, setIsGM] = useState(user?.role === 'master');
+  const [isGM, setIsGM] = useState(user?.role === 'gm');
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -44,7 +44,7 @@ export default function LobbyPage() {
       setPlayers(data.players);
       setGm(data.gm || null);
       if (user) {
-        setIsGM(user.role === 'master' || (data.gm && data.gm.toString() === user._id));
+        setIsGM(user.role === 'gm' || (data.gm && data.gm.toString() === user._id));
       }
     });
     socket.on('gm-assigned', () => {
@@ -57,7 +57,7 @@ export default function LobbyPage() {
 
   useEffect(() => {
     if (!user) return;
-    setIsGM(user.role === 'master' || (gm && gm.toString() === user._id));
+    setIsGM(user.role === 'gm' || (gm && gm.toString() === user._id));
   }, [user, gm]);
 
   const startGame = () => {
@@ -133,7 +133,7 @@ export default function LobbyPage() {
           {players.map(pl => (
             <li key={pl.user} className="text-dndgold mb-2">
               <div className="font-bold">
-                {pl.name} {pl.user === gm && ' (Мастер)'}
+                {pl.name} {pl.user === gm && ' (ГМ)'}
               </div>
               <div className="ml-2">
                 {pl.character ? (

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useUserStore } from '../store/user';
 import { useState, useEffect } from 'react';
 import api from "../api/axios";
+import getPostLoginRedirect from '../utils/getPostLoginRedirect.cjs';
 
 function LoginPage() {
   const [login, setLogin] = useState("");
@@ -48,7 +49,7 @@ function LoginPage() {
     try {
       const res = await api.post("/auth/login", { login, password });
       setUser(res.data.user, res.data.token);
-      navigate("/profile");
+      navigate(getPostLoginRedirect(res.data.user.role));
     } catch (err) {
       setError(err.response?.data?.message || "Login failed");
     } finally {

--- a/frontend/src/pages/admin/AdminUsersPage.jsx
+++ b/frontend/src/pages/admin/AdminUsersPage.jsx
@@ -20,7 +20,7 @@ export default function AdminUsersPage() {
   useEffect(() => { fetchUsers(); }, []);
 
   const toggleRole = async (id, role) => {
-    const newRole = role === 'master' ? 'player' : 'master';
+    const newRole = role === 'gm' ? 'player' : 'gm';
     try {
       await updateUserRole(id, newRole);
       setUsers(u => u.map(user => user._id === id ? { ...user, role: newRole } : user));

--- a/frontend/src/utils/getPostLoginRedirect.cjs
+++ b/frontend/src/utils/getPostLoginRedirect.cjs
@@ -1,0 +1,5 @@
+function getPostLoginRedirect(role) {
+  return role === 'gm' || role === 'admin' ? '/gm-dashboard' : '/profile';
+}
+
+module.exports = getPostLoginRedirect;

--- a/frontend/tests/loginRedirect.test.cjs
+++ b/frontend/tests/loginRedirect.test.cjs
@@ -1,0 +1,8 @@
+/** @jest-environment node */
+const getPostLoginRedirect = require('../src/utils/getPostLoginRedirect.cjs');
+
+test('gm role redirects to gm dashboard', () => {
+  expect(getPostLoginRedirect('gm')).toBe('/gm-dashboard');
+  expect(getPostLoginRedirect('admin')).toBe('/gm-dashboard');
+  expect(getPostLoginRedirect('player')).toBe('/profile');
+});


### PR DESCRIPTION
## Summary
- restrict allowed user roles and include `gm`
- enable registering users with `gm` or `admin` roles
- redirect GMs and admins to `/gm-dashboard`
- add GM dashboard and control panel placeholders
- add GM-related routes
- update all references from `master` to `gm`
- test GM login redirect logic

## Testing
- `./setup.sh`
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685683b140748322a091de53748cbfbc