### PR TITLE
Add GM control panel with socket context

### DIFF
--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -13,6 +13,8 @@ function getSession(id) {
       initiative: [],
       map: '',
       chat: [],
+      hp: {},
+      music: null,
       state: 'lobby'
     };
   }
@@ -102,6 +104,8 @@ function init(httpServer) {
         initiative: sess.initiative
       });
       if (sess.map) socket.emit('map-update', sess.map);
+      socket.emit('hp-update-all', sess.hp);
+      if (sess.music) socket.emit('music-change', sess.music);
     });
 
     socket.on('monster-add', ({ tableId, monster }) => {
@@ -126,6 +130,18 @@ function init(httpServer) {
       const sess = getSession(tableId);
       sess.map = map;
       io.to(tableId).emit('map-update', sess.map);
+    });
+
+    socket.on('player-hp-update', ({ tableId, userId, hp }) => {
+      const sess = getSession(tableId);
+      sess.hp[userId] = hp;
+      io.to(tableId).emit('player-hp-update', { userId, hp });
+    });
+
+    socket.on('music-change', ({ tableId, track }) => {
+      const sess = getSession(tableId);
+      sess.music = track;
+      io.to(tableId).emit('music-change', track);
     });
 
     socket.on('kick-player', ({ tableId, userId }) => {

--- a/backend/tests/socket.sync.test.js
+++ b/backend/tests/socket.sync.test.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const express = require('express');
+const Client = require('socket.io-client');
+const { init } = require('../src/socket');
+
+let ioServer, httpServer, addr;
+
+beforeAll((done) => {
+  const app = express();
+  httpServer = http.createServer(app);
+  ioServer = init(httpServer);
+  httpServer.listen(() => {
+    addr = httpServer.address();
+    done();
+  });
+});
+
+afterAll((done) => {
+  ioServer.close();
+  httpServer.close(done);
+});
+
+jest.setTimeout(10000);
+
+test('GM updates propagate to players', (done) => {
+  const url = `http://localhost:${addr.port}`;
+  const tableId = 't1';
+  const gm = { _id: 'g1', username: 'GM', role: 'master' };
+  const player = { _id: 'p1', username: 'PL', role: 'player' };
+
+  const c1 = Client(url);
+  const c2 = Client(url);
+
+  c1.emit('join-table', { tableId, user: gm });
+  c2.emit('join-table', { tableId, user: player });
+
+  let gotMap = false;
+  let gotHp = false;
+  let gotMusic = false;
+
+  const check = () => {
+    if (gotMap && gotHp && gotMusic) {
+      c1.close();
+      c2.close();
+      done();
+    }
+  };
+
+  c2.on('map-update', (m) => { expect(m).toBe('url1'); gotMap = true; check(); });
+  c2.on('player-hp-update', (d) => { expect(d.userId).toBe('p1'); expect(d.hp).toBe(3); gotHp = true; check(); });
+  c2.on('music-change', (t) => { expect(t).toBe('song.mp3'); gotMusic = true; check(); });
+
+  setTimeout(() => {
+    c1.emit('map-update', { tableId, map: 'url1' });
+    c1.emit('player-hp-update', { tableId, userId: 'p1', hp: 3 });
+    c1.emit('music-change', { tableId, track: 'song.mp3' });
+  }, 100);
+});

--- a/frontend/src/api/socket.js
+++ b/frontend/src/api/socket.js
@@ -1,0 +1,5 @@
+import { io } from 'socket.io-client';
+
+const socket = io(import.meta.env.VITE_SOCKET_URL || 'http://localhost:5000');
+
+export default socket;

--- a/frontend/src/components/GMControlPanel.jsx
+++ b/frontend/src/components/GMControlPanel.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import MusicPlayer from './MusicPlayer';
+import DiceBox from './DiceBox';
+import { useGameState } from '../context/GameStateContext';
+
+export default function GMControlPanel() {
+  const { updateMap, changeMusic } = useGameState();
+  const [mapUrl, setMapUrl] = useState('');
+  const [track, setTrack] = useState('');
+
+  const sendMap = () => {
+    if (!mapUrl) return;
+    updateMap(mapUrl);
+    setMapUrl('');
+  };
+
+  const sendMusic = () => {
+    if (!track) return;
+    changeMusic(track);
+    setTrack('');
+  };
+
+  return (
+    <div className="p-4 bg-[#25160f]/80 rounded-2xl text-dndgold flex flex-col gap-4 w-60">
+      <div>
+        <div className="font-bold mb-1">Карта</div>
+        <input
+          value={mapUrl}
+          onChange={e => setMapUrl(e.target.value)}
+          className="rounded px-2 py-1 w-full text-black mb-2"
+          placeholder="URL карти"
+        />
+        <button onClick={sendMap} className="bg-dndgold text-dndred font-dnd rounded px-2 py-1 w-full">
+          Оновити карту
+        </button>
+      </div>
+      <div>
+        <div className="font-bold mb-1">Музика</div>
+        <input
+          value={track}
+          onChange={e => setTrack(e.target.value)}
+          className="rounded px-2 py-1 w-full text-black mb-2"
+          placeholder="URL треку"
+        />
+        <button onClick={sendMusic} className="bg-dndgold text-dndred font-dnd rounded px-2 py-1 w-full">
+          Відтворити
+        </button>
+      </div>
+      <MusicPlayer isGM className="w-full" />
+      <DiceBox />
+    </div>
+  );
+}

--- a/frontend/src/components/GMTableView.jsx
+++ b/frontend/src/components/GMTableView.jsx
@@ -1,0 +1,13 @@
+import MapViewer from './MapViewer';
+import PlayerStatusTable from './PlayerStatusTable';
+import { useGameState } from '../context/GameStateContext';
+
+export default function GMTableView({ players, isGM }) {
+  const { map } = useGameState();
+  return (
+    <div className="flex flex-col items-center gap-4 w-full">
+      <MapViewer mapUrl={map} />
+      <PlayerStatusTable players={players} isGM={isGM} />
+    </div>
+  );
+}

--- a/frontend/src/components/PlayerStatusTable.jsx
+++ b/frontend/src/components/PlayerStatusTable.jsx
@@ -1,0 +1,36 @@
+import { useGameState } from '../context/GameStateContext';
+
+export default function PlayerStatusTable({ players, isGM }) {
+  const { hp, updateHp } = useGameState();
+  return (
+    <table className="text-dndgold text-sm w-full">
+      <thead>
+        <tr>
+          <th className="text-left">Гравець</th>
+          <th className="text-left">HP</th>
+          <th className="text-left">Статус</th>
+        </tr>
+      </thead>
+      <tbody>
+        {players.map(p => (
+          <tr key={p.user} className="border-t border-dndgold/20">
+            <td>{p.name}</td>
+            <td>
+              {isGM ? (
+                <input
+                  type="number"
+                  value={hp[p.user] ?? ''}
+                  onChange={e => updateHp(p.user, Number(e.target.value))}
+                  className="w-16 text-black rounded"
+                />
+              ) : (
+                hp[p.user] ?? '-'
+              )}
+            </td>
+            <td>{p.status || ''}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/context/GameStateContext.jsx
+++ b/frontend/src/context/GameStateContext.jsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import socket from '../api/socket';
+
+const GameStateContext = createContext();
+
+export function GameStateProvider({ tableId, user, children }) {
+  const [map, setMap] = useState('');
+  const [hp, setHp] = useState({});
+  const [music, setMusic] = useState(null);
+
+  useEffect(() => {
+    if (!tableId || !user) return;
+    socket.emit('join-table', { tableId, user });
+    const onMap = (m) => setMap(m);
+    const onHpAll = (data) => setHp(data || {});
+    const onHp = ({ userId, hp: val }) => setHp(h => ({ ...h, [userId]: val }));
+    const onMusic = (track) => setMusic(track);
+    socket.on('map-update', onMap);
+    socket.on('hp-update-all', onHpAll);
+    socket.on('player-hp-update', onHp);
+    socket.on('music-change', onMusic);
+    return () => {
+      socket.off('map-update', onMap);
+      socket.off('hp-update-all', onHpAll);
+      socket.off('player-hp-update', onHp);
+      socket.off('music-change', onMusic);
+      socket.disconnect();
+    };
+  }, [tableId, user]);
+
+  const updateMap = (m) => socket.emit('map-update', { tableId, map: m });
+  const updateHp = (uid, val) => socket.emit('player-hp-update', { tableId, userId: uid, hp: val });
+  const changeMusic = (track) => socket.emit('music-change', { tableId, track });
+
+  return (
+    <GameStateContext.Provider value={{ map, hp, music, updateMap, updateHp, changeMusic }}>
+      {children}
+    </GameStateContext.Provider>
+  );
+}
+
+export const useGameState = () => useContext(GameStateContext);

--- a/frontend/src/pages/GameTablePage.jsx
+++ b/frontend/src/pages/GameTablePage.jsx
@@ -1,18 +1,15 @@
-import GMPanel from "../components/GMPanel";
 import InitiativeList from "../components/InitiativeList";
 import ChatComponent from "../components/ChatComponent";
 import PlayerCard from "../components/PlayerCard";
-import MusicPlayer from "../components/MusicPlayer";
 import DiceBox from "../components/DiceBox";
 import LogoutButton from "../components/LogoutButton";
+import GMTableView from "../components/GMTableView";
+import GMControlPanel from "../components/GMControlPanel";
 import { useState, useEffect } from 'react';
-import { io } from 'socket.io-client';
+import socket from '../api/socket';
+import { GameStateProvider, useGameState } from '../context/GameStateContext';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { useUserStore } from '../store/user';
-
-// socket connection URL configurable via env
-// Fallback to localhost if env variable is missing
-const socket = io(import.meta.env.VITE_SOCKET_URL || 'http://localhost:5000');
 
 export default function GameTablePage() {
   const { user } = useUserStore();
@@ -24,12 +21,11 @@ export default function GameTablePage() {
   const [gm, setGm] = useState(null);
   const [visiblePlayers, setVisiblePlayers] = useState([]);
   const [initiative, setInitiative] = useState([]);
-  const [map, setMap] = useState("");
   const [messages, setMessages] = useState([]);
+  const { map } = useGameState();
 
   // SOCKET.IO підключення
   useEffect(() => {
-    socket.emit("join-table", { tableId, user, characterId });
     socket.on("table-players", data => {
       setPlayers(data.players || []);
       setGm(data.gm || null);
@@ -37,16 +33,21 @@ export default function GameTablePage() {
       setVisiblePlayers((data.players || []).filter(p => p.user !== data.gm));
     });
     socket.on("initiative-update", setInitiative);
-    socket.on("map-update", setMap);
     socket.on("chat-history", setMessages);
     socket.on("chat-message", msg => setMessages(m => [...m, msg]));
-    return () => socket.disconnect();
+    return () => {
+      socket.off("table-players");
+      socket.off("initiative-update");
+      socket.off("chat-history");
+      socket.off("chat-message");
+    };
   }, [tableId, user, characterId]);
 
   const isGM = (user?.role === 'master') || (gm && user && gm.toString() === user._id);
 
 
   return (
+    <GameStateProvider tableId={tableId} user={user}>
     <div
       style={{
         minHeight: "100vh",
@@ -89,13 +90,7 @@ export default function GameTablePage() {
         </div>
         {/* Центральна зона столу */}
         <div className="flex flex-col items-center justify-center h-full z-0 md:mx-60">
-          <div className="w-full h-[40vh] flex items-center justify-center rounded-2xl shadow-dnd bg-[#160b06]/90 mb-4 border-2 border-dndgold">
-            {map ? (
-              <img src={map} alt="Map" className="max-h-full max-w-full rounded-xl" />
-            ) : (
-              <span className="text-dndgold font-dnd text-2xl">[Карта ще не обрана]</span>
-            )}
-          </div>
+          <GMTableView players={players} isGM={isGM} />
           <InitiativeList initiative={initiative} />
         </div>
         {/* Нижня панель */}
@@ -105,9 +100,7 @@ export default function GameTablePage() {
           {isGM ? (
             <>
               <ChatComponent tableId={tableId} user={user} messages={messages} socket={socket} />
-              <MusicPlayer isGM={isGM} className="w-32 md:w-40" />
-              <GMPanel tableId={tableId} socket={socket} players={players} className="w-48" />
-              <DiceBox className="self-end w-40" />
+              <GMControlPanel />
             </>
           ) : (
             <>
@@ -123,5 +116,6 @@ export default function GameTablePage() {
         © {new Date().getFullYear()} D&D Online Tabletop
       </div>
     </div>
+    </GameStateProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add music/map/HP sync to backend sockets
- implement shared GameState context and socket helper
- create GM view components and update table page
- test realtime sync between GM and player

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68568431c3bc8322a47db0abcb00e079