### PR TITLE
Fix missing GM page imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project combines an Express/MongoDB backend with a React frontend.
    ```bash
    ./setup.sh
    ```
+   You may optionally run `npm audit fix --force` inside `backend` and
+   `frontend` to address any security warnings.
 
 2. **Environment variables**
    Copy `backend/.env.example` to `backend/.env` and adjust the values:
@@ -158,8 +160,8 @@ take up the role:
 ### Stat Generation
 
 When generating stats, race bonuses apply first. Class minimums then raise any
-insufficient attributes. Finally, untouched stats are randomised between **8**
-and **15**, but never drop below their current value.
+insufficient attributes. Finally, untouched stats are randomised between **3**
+and **10**, but never drop below their current value.
 
 ```js
 const stats = generateStats('Ельф (жінка)', 'Маг');

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,8 @@ import SettingsPanel from './pages/SettingsPanel';
 import GMDashboard from './pages/GMDashboard';
 import GMControlPanel from './pages/GMControlPanel';
 
-
+import GMDashboardPage from './pages/gm/GMDashboardPage';
+import GMControlPage from './pages/gm/GMControlPage';
 import GMTablePage from './pages/gm/GMTablePage';
 
 import PrivateRoute from './PrivateRoute';


### PR DESCRIPTION
## Summary
- import the GM page components in `App.jsx`
- document optional `npm audit` fix step
- clarify stat generation range

## Testing
- `./setup.sh`
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68568bc59cfc83229f071452167d2e3f