### PR TITLE
Fix stat generation range

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ take up the role:
 ### Stat Generation
 
 When generating stats, race bonuses apply first. Class minimums then raise any
-insufficient attributes. Finally, untouched stats are randomised between **8**
-and **15**, but never drop below their current value.
+insufficient attributes. Finally, untouched stats are randomised between **3**
+and **10**, but never drop below their current value.
 
 ```js
 const stats = generateStats('Ельф (жінка)', 'Маг');


### PR DESCRIPTION
## Summary
- correct random stat generation range in README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68568cd2d5b48322b41729b5c8f90d62