### PR TITLE
Update README about audit warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project combines an Express/MongoDB backend with a React frontend.
    ./setup.sh
    ```
 
+   If `npm audit` prints warnings afterwards, you can run `npm audit fix`
+   (or `npm audit fix --force` if necessary) in each directory to address
+   potential vulnerabilities.
+
 2. **Environment variables**
    Copy `backend/.env.example` to `backend/.env` and adjust the values:
    - `MONGO_URI` – MongoDB connection string
@@ -116,6 +120,8 @@ cd backend
 npm run lint
 npm run format
 ```
+
+The frontend does not currently include separate lint or format commands.
 
 ## Character Basics
 


### PR DESCRIPTION
## Summary
- add instructions for fixing `npm audit` issues
- document that only the backend has lint/format scripts

## Testing
- `npm test` in `backend` *(fails: socket.startGame)*
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68568cd4a614832281573b0b93990579