### PR TITLE
Sanitize chat markdown

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.6.0",
         "chart.js": "^4.4.9",
         "clsx": "^2.1.0",
+        "dompurify": "^3.2.6",
         "framer-motion": "^11.0.0",
         "i18next": "^23.0.1",
         "lucide-react": "^0.346.0",
@@ -2185,6 +2186,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -3156,6 +3164,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "react-player": "^2.12.0",
     "react-router-dom": "^6.30.1",
     "socket.io-client": "^4.7.5",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { io } from 'socket.io-client';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useUserStore } from '../store/user';
 
@@ -45,7 +46,11 @@ export default function ChatBox({ sessionId }) {
                 className={`mb-1 ${msg.userRole === 'gm' ? 'bg-dndred/30 text-dndgold px-1 rounded' : ''}`}
               >
                 <span className="font-dnd text-dndgold/80">{msg.user || 'Гість'}:</span>{' '}
-                <span dangerouslySetInnerHTML={{ __html: marked.parse(msg.text || '') }} />
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(marked.parse(msg.text || '')),
+                  }}
+                />
               </motion.div>
             ))}
           </AnimatePresence>

--- a/frontend/src/components/ChatComponent.jsx
+++ b/frontend/src/components/ChatComponent.jsx
@@ -1,6 +1,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function ChatComponent({ tableId, user, messages, socket }) {
@@ -33,7 +34,11 @@ export default function ChatComponent({ tableId, user, messages, socket }) {
                 className={`mb-1 ${m.userRole === 'gm' ? 'bg-dndred/30 text-dndgold px-1 rounded' : ''}`}
               >
                 <b>{m.user}:</b>{' '}
-                <span dangerouslySetInnerHTML={{ __html: marked.parse(m.text || '') }} />
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(marked.parse(m.text || '')),
+                  }}
+                />
               </motion.div>
             ))}
           </AnimatePresence>


### PR DESCRIPTION
## Summary
- sanitize Markdown rendering in ChatBox and ChatComponent
- add `dompurify` to frontend dependencies

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685690da0af483229243c13f9f09d066