### PR TITLE
Replace master role with gm

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cd ../frontend && npm test
 
 After signing in, players and game masters land on different pages. Regular players
 are redirected to `/characters` where they can manage their heroes. Users with the
-`master` role start at `/gm-dashboard` and gain access to additional GM routes:
+`gm` role start at `/gm-dashboard` and gain access to additional GM routes:
 
 - `/gm-dashboard` – overview for game masters
 - `/gm-table/:id` – run a specific table

--- a/backend/tests/socket.sync.test.js
+++ b/backend/tests/socket.sync.test.js
@@ -25,7 +25,7 @@ jest.setTimeout(10000);
 test('GM updates propagate to players', (done) => {
   const url = `http://localhost:${addr.port}`;
   const tableId = 't1';
-  const gm = { _id: 'g1', username: 'GM', role: 'master' };
+  const gm = { _id: 'g1', username: 'GM', role: 'gm' };
   const player = { _id: 'p1', username: 'PL', role: 'player' };
 
   const c1 = Client(url);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,7 +32,7 @@ const isAdmin = () => {
 const isGM = () => {
   try {
     const data = JSON.parse(localStorage.getItem('user-storage') || '{}');
-    return data.state?.user?.role === 'master';
+    return data.state?.user?.role === 'gm';
   } catch {
     return false;
   }
@@ -63,9 +63,9 @@ const App = () => {
 
 
     <Route path="/table/:tableId" element={<GameTablePage />} />
-    <Route path="/gm-dashboard" element={<PrivateRoute roles={['master']}><GMDashboard /></PrivateRoute>} />
-    <Route path="/gm-table/:id" element={<PrivateRoute roles={['master']}><GameTablePage /></PrivateRoute>} />
-    <Route path="/gm-control/:id" element={<PrivateRoute roles={['master']}><GMControlPage /></PrivateRoute>} />
+    <Route path="/gm-dashboard" element={<PrivateRoute roles={['gm']}><GMDashboard /></PrivateRoute>} />
+    <Route path="/gm-table/:id" element={<PrivateRoute roles={['gm']}><GameTablePage /></PrivateRoute>} />
+    <Route path="/gm-control/:id" element={<PrivateRoute roles={['gm']}><GMControlPage /></PrivateRoute>} />
     <Route path="*" element={<Navigate to="/" />} />
   </Routes>
   );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -52,7 +52,7 @@ function LoginPage() {
 
       navigate(getPostLoginRedirect(res.data.user.role));
 
-      if (res.data.user.role === 'master') {
+      if (res.data.user.role === 'gm') {
         navigate('/gm-dashboard');
       } else {
         navigate('/characters');


### PR DESCRIPTION
## Summary
- rename `master` to `gm` in role checks and routes
- update login redirect to handle `gm`
- adjust test fixture
- document `gm` role

## Testing
- `npm test` within `backend`
- `npm test` within `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68569a8ace34832290c467266a10af01