### PR TITLE
Add Table model with CRUD endpoints

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -48,6 +48,7 @@ app.use('/api/music', require('./routes/music'));
 app.use('/api/profession', require('./routes/profession'));
 app.use('/api/race', require('./routes/race'));
 app.use('/api/roll', require('./routes/roll'));
+app.use('/api/table', require('./routes/table'));
 app.use('/api/session', require('./routes/session'));
 app.use('/api/user', require('./routes/user'));
 

--- a/backend/src/models/Table.js
+++ b/backend/src/models/Table.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const TableSchema = new mongoose.Schema({
+  tableId: { type: String, required: true, unique: true },
+  gm: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  players: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+  state: { type: String, default: 'lobby' }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Table', TableSchema);

--- a/backend/src/routes/table.js
+++ b/backend/src/routes/table.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const router = express.Router();
+const Table = require('../models/Table');
+const auth = require('../middlewares/authMiddleware');
+const gm = require('../middlewares/onlyMaster');
+
+// Create a new table (gm only)
+router.post('/', auth, gm, async (req, res) => {
+  try {
+    const tableId = Math.random().toString(36).substring(2, 8);
+    const table = new Table({ tableId, gm: req.user._id });
+    await table.save();
+    res.status(201).json(table);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// Get table by id
+router.get('/:id', auth, async (req, res) => {
+  try {
+    const table = await Table.findOne({ tableId: req.params.id });
+    if (!table) return res.status(404).json({ message: 'Table not found' });
+    res.json(table);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// Update table (gm only)
+router.put('/:id', auth, gm, async (req, res) => {
+  try {
+    const table = await Table.findOneAndUpdate(
+      { tableId: req.params.id },
+      req.body,
+      { new: true }
+    );
+    if (!table) return res.status(404).json({ message: 'Table not found' });
+    res.json(table);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// List tables
+router.get('/', auth, async (req, res) => {
+  try {
+    const tables = await Table.find({ gm: req.user._id });
+    res.json(tables);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/pages/GMDashboard.jsx
+++ b/frontend/src/pages/GMDashboard.jsx
@@ -1,12 +1,18 @@
 import { useNavigate } from 'react-router-dom';
+import api from "../api/axios";
 
 export default function GMDashboard() {
   const navigate = useNavigate();
 
-  const createTable = () => {
-    const tableId = Math.random().toString(36).substring(2, 8);
-    navigate(`/gm-table/${tableId}`);
-    window.open(`/gm-control/${tableId}`, '_blank');
+  const createTable = async () => {
+    try {
+      const res = await api.post('/table');
+      const { tableId } = res.data;
+      navigate(`/gm-table/${tableId}`);
+      window.open(`/gm-control/${tableId}`, '_blank');
+    } catch {
+      // fail silently
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- implement `Table` mongoose model
- add `/api/table` CRUD routes with auth and GM checks
- integrate table routes into Express app
- update GM dashboard to create tables via API

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68569a8b8c208322a5adae52acdca598