### PR TITLE
Replace master with gm in socket test

### DIFF
--- a/backend/tests/socket.sync.test.js
+++ b/backend/tests/socket.sync.test.js
@@ -25,7 +25,7 @@ jest.setTimeout(10000);
 test('GM updates propagate to players', (done) => {
   const url = `http://localhost:${addr.port}`;
   const tableId = 't1';
-  const gm = { _id: 'g1', username: 'GM', role: 'master' };
+  const gm = { _id: 'g1', username: 'GM', role: 'gm' };
   const player = { _id: 'p1', username: 'PL', role: 'player' };
 
   const c1 = Client(url);


### PR DESCRIPTION
## Summary
- update socket sync test to use `gm` role rather than `master`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68569a8e072883228223e09998f12a93