### PR TITLE
Extend table data model

### DIFF
--- a/backend/src/models/Table.js
+++ b/backend/src/models/Table.js
@@ -4,7 +4,10 @@ const TableSchema = new mongoose.Schema({
   tableId: { type: String, required: true, unique: true },
   gm: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   players: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
-  state: { type: String, default: 'lobby' }
+  state: { type: String, default: 'lobby' },
+  mapUrl: { type: String, default: '' },
+  musicTrack: { type: String, default: '' },
+  playerInfo: { type: mongoose.Schema.Types.Mixed, default: {} }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Table', TableSchema);

--- a/backend/src/routes/table.js
+++ b/backend/src/routes/table.js
@@ -30,9 +30,14 @@ router.get('/:id', auth, async (req, res) => {
 // Update table (gm only)
 router.put('/:id', auth, gm, async (req, res) => {
   try {
+    const allowed = ['mapUrl', 'musicTrack', 'playerInfo', 'players', 'state'];
+    const update = {};
+    for (const key of allowed) {
+      if (key in req.body) update[key] = req.body[key];
+    }
     const table = await Table.findOneAndUpdate(
       { tableId: req.params.id },
-      req.body,
+      update,
       { new: true }
     );
     if (!table) return res.status(404).json({ message: 'Table not found' });

--- a/backend/tests/table.test.js
+++ b/backend/tests/table.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+  req.user = { _id: 'u1', role: 'gm' };
+  next();
+}));
+
+jest.mock('../src/middlewares/onlyMaster', () => jest.fn((req, res, next) => next()));
+
+const Table = require('../src/models/Table');
+
+jest.mock('../src/models/Table');
+
+const tableRouter = require('../src/routes/table');
+
+const app = express();
+app.use(express.json());
+app.use('/api/table', tableRouter);
+
+describe('Table Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/table/:id returns extended fields', async () => {
+    Table.findOne.mockResolvedValue({
+      tableId: 't1',
+      gm: 'u1',
+      players: [],
+      state: 'active',
+      mapUrl: 'map.png',
+      musicTrack: 'song.mp3',
+      playerInfo: { u1: { hp: 5, status: 'ok' } }
+    });
+
+    const res = await request(app).get('/api/table/t1');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.mapUrl).toBe('map.png');
+    expect(res.body.musicTrack).toBe('song.mp3');
+    expect(res.body.playerInfo.u1.hp).toBe(5);
+    expect(Table.findOne).toHaveBeenCalledWith({ tableId: 't1' });
+  });
+
+  it('PUT /api/table/:id updates allowed fields', async () => {
+    Table.findOneAndUpdate.mockResolvedValue({
+      tableId: 't1',
+      gm: 'u1',
+      players: [],
+      state: 'active',
+      mapUrl: 'new.png',
+      musicTrack: 'new.mp3',
+      playerInfo: { u1: { hp: 1, status: 'down' } }
+    });
+
+    const payload = { mapUrl: 'new.png', musicTrack: 'new.mp3', playerInfo: { u1: { hp: 1, status: 'down' } } };
+
+    const res = await request(app).put('/api/table/t1').send(payload);
+
+    expect(res.statusCode).toBe(200);
+    expect(Table.findOneAndUpdate).toHaveBeenCalledWith(
+      { tableId: 't1' },
+      payload,
+      { new: true }
+    );
+    expect(res.body.mapUrl).toBe('new.png');
+  });
+});


### PR DESCRIPTION
## Summary
- expand `Table` model with map, music and player info fields
- restrict table updates to only editable fields
- test table route for new fields

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68569e8314848322b821af34f29ae401