### PR TITLE
Update login redirect

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -51,12 +51,6 @@ function LoginPage() {
       setUser(res.data.user, res.data.token);
 
       navigate(getPostLoginRedirect(res.data.user.role));
-
-      if (res.data.user.role === 'gm') {
-        navigate('/gm-dashboard');
-      } else {
-        navigate('/characters');
-      }
     } catch (err) {
       setError(err.response?.data?.message || "Login failed");
     } finally {

--- a/frontend/src/utils/getPostLoginRedirect.cjs
+++ b/frontend/src/utils/getPostLoginRedirect.cjs
@@ -1,5 +1,5 @@
 function getPostLoginRedirect(role) {
-  return role === 'gm' || role === 'admin' ? '/gm-dashboard' : '/profile';
+  return role === 'gm' || role === 'admin' ? '/gm-dashboard' : '/characters';
 }
 
 module.exports = getPostLoginRedirect;

--- a/frontend/tests/loginRedirect.test.cjs
+++ b/frontend/tests/loginRedirect.test.cjs
@@ -4,5 +4,5 @@ const getPostLoginRedirect = require('../src/utils/getPostLoginRedirect.cjs');
 test('gm role redirects to gm dashboard', () => {
   expect(getPostLoginRedirect('gm')).toBe('/gm-dashboard');
   expect(getPostLoginRedirect('admin')).toBe('/gm-dashboard');
-  expect(getPostLoginRedirect('player')).toBe('/profile');
+  expect(getPostLoginRedirect('player')).toBe('/characters');
 });


### PR DESCRIPTION
## Summary
- update post login redirect helper
- update test for new redirect path
- simplify login navigation logic

## Testing
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6856a375c574832298747eff7763f675