### PR TITLE
Fix login state persistence and translations

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "welcome": "Welcome",
   "login": "Login",
+  "password": "Password",
   "register": "Register",
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -1,6 +1,7 @@
 {
   "welcome": "Ласкаво просимо",
   "login": "Увійти",
+  "password": "Пароль",
   "register": "Реєстрація",
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,10 +1,13 @@
-// LoginPage.jsx (patched)
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
+import { useUserStore } from '../store/user';
 
 function LoginPage() {
   const navigate = useNavigate();
+  const { t } = useTranslation();
+  const setUser = useUserStore((s) => s.setUser);
 
   const handleLogin = async (event) => {
     event.preventDefault();
@@ -15,19 +18,16 @@ function LoginPage() {
       password: password.value,
     });
 
-    const user = res.data;
-    if (user.role === 'gm') {
-      navigate('/gm-dashboard');
-    } else {
-      navigate('/characters');
-    }
+    const { user, token } = res.data;
+    setUser(user, token);
+    navigate(user.role === 'gm' ? '/gm-dashboard' : '/characters');
   };
 
   return (
     <form onSubmit={handleLogin}>
-      <input name='username' placeholder='Username' />
-      <input name='password' placeholder='Password' type='password' />
-      <button type='submit'>Login</button>
+      <input name='username' placeholder={t('login')} />
+      <input name='password' placeholder={t('password')} type='password' />
+      <button type='submit'>{t('login')}</button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- store auth token using `setUser`
- redirect players to role-appropriate dashboard
- translate login form placeholders

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685809cbf3f48322ba38c422e40bd433