### PR TITLE
Remove duplicate postcss config

### DIFF
--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,7 +1,0 @@
-
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}


### PR DESCRIPTION
## Summary
- keep only the ES module `postcss.config.js` since the project uses ESM
- delete obsolete `postcss.config.cjs`

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685809d0107c8322ae08d47d02a2a260