### PR TITLE
Fix CharacterCard race key handling

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -3,22 +3,25 @@ import { useTranslation } from 'react-i18next';
 
 export default function CharacterCard({ character }) {
   const { t } = useTranslation();
+  const raceKey =
+    typeof character.race === 'string'
+      ? character.race
+      : character.race?.code;
 
   return (
     <div className='character-card'>
       <h3>{character.name}</h3>
       <p>
-        {t(
-          `races.${(character.race?.code || character.race || '').toLowerCase()}`,
-          character.race?.name || character.race
-        )}
+        {raceKey
+          ? t(`races.${raceKey.toLowerCase()}`, character.race?.name || raceKey)
+          : t('unknown')}
       </p>
       <p>
         {t(
           `classes.${(
-            character.class?.code || character.class || ''
+            character.profession?.code || character.profession || ''
           ).toLowerCase()}`,
-          character.class?.name || character.class
+          character.profession?.name || character.profession
         )}
       </p>
       <ul>


### PR DESCRIPTION
## Summary
- ensure character race strings are handled safely in `CharacterCard`
- replace usage of `character.class` with `character.profession`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685814f5788c8322afb2ad4f0e7fce5e