### PR TITLE
Fix race/class translation keys

### DIFF
--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -19,6 +19,16 @@ export default function PlayerCard({ character, onSelect }) {
     character.profession?.code || character.profession?.name
   );
 
+  const raceKey =
+    typeof (character.race?.code || character.race) === 'string'
+      ? (character.race?.code || character.race).toLowerCase()
+      : '';
+
+  const classKey =
+    typeof (character.profession?.code || character.profession) === 'string'
+      ? (character.profession?.code || character.profession).toLowerCase()
+      : '';
+
   return (
     <>
       <motion.div
@@ -34,16 +44,12 @@ export default function PlayerCard({ character, onSelect }) {
         />
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
-          {t(
-            `races.${(character.race?.code || character.race || '').toLowerCase()}`,
-            character.race?.name || character.race?.code || ''
-          )}{' '}/{' '}
-          {t(
-            `classes.${(
-              character.profession?.code || character.profession || ''
-            ).toLowerCase()}`,
-            character.profession?.name || character.profession?.code || ''
-          )}
+          {raceKey
+            ? t(`races.${raceKey}`, character.race?.name || character.race?.code || '')
+            : t('unknown')}{' '}/{' '}
+          {classKey
+            ? t(`classes.${classKey}`, character.profession?.name || character.profession?.code || '')
+            : t('unknown')}
         </p>
         <button
           onClick={() => setOpen(true)}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,6 +6,7 @@
   "admin": "Admin",
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",
+  "unknown": "Unknown",
   "races": {
     "human_male": "Human (male)",
     "human_female": "Human (female)",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -6,6 +6,7 @@
   "admin": "Адмінка",
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",
+  "unknown": "Невідомо",
   "races": {
     "human_male": "Людина (чоловік)",
     "human_female": "Людина (жінка)",


### PR DESCRIPTION
## Summary
- avoid errors when translation keys are missing in PlayerCard
- add fallback `unknown` text in both locales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685814f76e5083228b242b402ac07fde