### PR TITLE
Fix getClassBorderColor

### DIFF
--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -8,7 +8,8 @@ export function getClassBorderColor(profession) {
     healer: 'border-teal-600',
     druid: 'border-green-700',
   };
-  if (!profession) return 'border-dndgold';
+  if (typeof profession !== 'string' || profession.trim() === '')
+    return 'border-dndgold';
   const key = profession.toLowerCase();
   return map[key] || 'border-dndgold';
 }


### PR DESCRIPTION
## Summary
- prevent `.toLowerCase()` calls on non-strings in `getClassBorderColor`
- default to `border-dndgold` when `profession` isn't a valid string

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685814fa67f48322bf42cab1bbbf6b7e