### PR TITLE
Add unknown localization and fallback

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -10,7 +10,7 @@ export default function CharacterCard({ character }) {
       <p>
         {t(
           `races.${(character.race?.code || character.race || '').toLowerCase()}`,
-          character.race?.name || character.race
+          t('unknown')
         )}
       </p>
       <p>
@@ -18,13 +18,13 @@ export default function CharacterCard({ character }) {
           `classes.${(
             character.class?.code || character.class || ''
           ).toLowerCase()}`,
-          character.class?.name || character.class
+          t('unknown')
         )}
       </p>
       <ul>
         {Object.entries(character.stats || {}).map(([key, value]) => (
           <li key={key}>
-            {t(`stats.${key.toLowerCase()}`, key)}: {value}
+            {t(`stats.${key.toLowerCase()}`, t('unknown'))}: {value}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -8,7 +8,7 @@ import Modal from './Modal';
 function translateEffect(effectString, t) {
   return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
     const key = stat.toLowerCase();
-    return `+${num} ${t('stats.' + key, stat)}`;
+    return `+${num} ${t('stats.' + key, t('unknown'))}`;
   });
 }
 
@@ -36,13 +36,13 @@ export default function PlayerCard({ character, onSelect }) {
         <p className="text-xs text-center">
           {t(
             `races.${(character.race?.code || character.race || '').toLowerCase()}`,
-            character.race?.name || character.race?.code || ''
+            t('unknown')
           )}{' '}/{' '}
           {t(
             `classes.${(
               character.profession?.code || character.profession || ''
             ).toLowerCase()}`,
-            character.profession?.name || character.profession?.code || ''
+            t('unknown')
           )}
         </p>
         <button
@@ -66,7 +66,7 @@ export default function PlayerCard({ character, onSelect }) {
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
             {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {t(`stats.${key.toLowerCase()}`, key)}: {val}
+                {t(`stats.${key.toLowerCase()}`, t('unknown'))}: {val}
               </li>
             ))}
           </ul>
@@ -79,7 +79,7 @@ export default function PlayerCard({ character, onSelect }) {
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), k)}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
                         .join(', ') +
                       ')'
                   : '';

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,6 +6,7 @@
   "admin": "Admin",
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",
+  "unknown": "Unknown",
   "races": {
     "human_male": "Human (male)",
     "human_female": "Human (female)",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -6,6 +6,7 @@
   "admin": "Адмінка",
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",
+  "unknown": "Невідомо",
   "races": {
     "human_male": "Людина (чоловік)",
     "human_female": "Людина (жінка)",

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -21,10 +21,10 @@ export default function CharacterListPage() {
             <h2 className="text-xl text-dndgold">{c.name}</h2>
             <p className="text-base italic mb-2">{c.description}</p>
             <p className="text-xs">
-              Раса: {c.race?.code ? t(`races.${c.race.code.toLowerCase()}`, c.race.name || c.race.code) : (c.race?.name || '—')}
+              Раса: {c.race?.code ? t(`races.${c.race.code.toLowerCase()}`, t('unknown')) : (c.race?.name || t('unknown'))}
             </p>
             <p className="text-xs">
-              Клас: {c.profession?.code ? t(`classes.${c.profession.code.toLowerCase()}`, c.profession.name || c.profession.code) : (c.profession?.name || '—')}
+              Клас: {c.profession?.code ? t(`classes.${c.profession.code.toLowerCase()}`, t('unknown')) : (c.profession?.name || t('unknown'))}
             </p>
             <button
               onClick={() => navigate(`/lobby?char=${c._id}`)}


### PR DESCRIPTION
## Summary
- add `unknown` translation key for English/Ukrainian
- show `t('unknown')` for unknown race/class/stats
- use unknown fallback on character list page

## Testing
- `npm test --silent` *(fails: jest not found until dependencies installed, then 0 tests run)*
- `npm test --silent` in backend *(1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_685814faf8e88322a16714c83eae2103