### PR TITLE
Improve inventory display handling

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { normalizeInventory } from '../utils/inventoryUtils';
 
 export default function CharacterCard({ character }) {
   const { t } = useTranslation();
@@ -37,9 +38,16 @@ export default function CharacterCard({ character }) {
       </ul>
       <h4>Інвентар:</h4>
       <ul>
-        {(character.inventory || []).map((item, index) => (
-          <li key={index}>{item}</li>
-        ))}
+        {(() => {
+          const inv = normalizeInventory(character.inventory);
+          if (inv.type === 'array') {
+            return inv.items.map((item, index) => <li key={index}>{item}</li>);
+          }
+          if (inv.type === 'object') {
+            return inv.items.map(([key, item]) => <li key={key}>{item}</li>);
+          }
+          return <li>Інвентар порожній</li>;
+        })()}
       </ul>
     </div>
   );

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -4,6 +4,7 @@ import { withApiHost } from '../utils/imageUtils';
 import { useTranslation } from 'react-i18next';
 import { getClassBorderColor } from '../utils/classColors';
 import Modal from './Modal';
+import { normalizeInventory } from '../utils/inventoryUtils';
 
 function translateEffect(effectString, t) {
   return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
@@ -77,29 +78,64 @@ export default function PlayerCard({ character, onSelect }) {
             ))}
           </ul>
         )}
-        {character.inventory && character.inventory.length > 0 && (
-          <ul className="list-disc pl-4 mt-2 space-y-0.5">
-            {character.inventory.map((it, idx) => {
-              const bonus =
-                it.bonus && Object.keys(it.bonus).length
-                  ?
-                      ' (' +
-                      Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
-                        .join(', ') +
-                      ')'
-                  : '';
-              return (
-                <li key={idx}>
-                  {it.item}
-                  {it.amount > 1 ? ` x${it.amount}` : ''}
-                  {bonus}
-                  {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
-                </li>
-              );
-            })}
-          </ul>
-        )}
+        {(() => {
+          const inv = normalizeInventory(character.inventory);
+          if (inv.type === 'array' && inv.items.length > 0) {
+            return (
+              <ul className="list-disc pl-4 mt-2 space-y-0.5">
+                {inv.items.map((it, idx) => {
+                  const bonus =
+                    it.bonus && Object.keys(it.bonus).length
+                      ?
+                          ' (' +
+                          Object.entries(it.bonus)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .join(', ') +
+                          ')'
+                      : '';
+                  return (
+                    <li key={idx}>
+                      {it.item}
+                      {it.amount > 1 ? ` x${it.amount}` : ''}
+                      {bonus}
+                      {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          }
+          if (inv.type === 'object' && inv.items.length > 0) {
+            return (
+              <ul className="list-disc pl-4 mt-2 space-y-0.5">
+                {inv.items.map(([key, it]) => {
+                  const bonus =
+                    it.bonus && Object.keys(it.bonus).length
+                      ?
+                          ' (' +
+                          Object.entries(it.bonus)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .join(', ') +
+                          ')'
+                      : '';
+                  return (
+                    <li key={key}>
+                      {it.item}
+                      {it.amount > 1 ? ` x${it.amount}` : ''}
+                      {bonus}
+                      {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          }
+          return (
+            <ul className="list-disc pl-4 mt-2 space-y-0.5">
+              <li>Інвентар порожній</li>
+            </ul>
+          );
+        })()}
       </Modal>
     </>
   );

--- a/frontend/src/utils/inventoryUtils.js
+++ b/frontend/src/utils/inventoryUtils.js
@@ -1,0 +1,9 @@
+export function normalizeInventory(inventory) {
+  if (Array.isArray(inventory)) {
+    return { type: 'array', items: inventory };
+  }
+  if (inventory && typeof inventory === 'object') {
+    return { type: 'object', items: Object.entries(inventory) };
+  }
+  return { type: 'empty', items: [] };
+}

--- a/frontend/tests/inventoryUtils.test.cjs
+++ b/frontend/tests/inventoryUtils.test.cjs
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+
+test('normalizeInventory handles array', async () => {
+  const { normalizeInventory } = await import('../src/utils/inventoryUtils.js');
+  const result = normalizeInventory(['a', 'b']);
+  expect(result).toEqual({ type: 'array', items: ['a', 'b'] });
+});
+
+test('normalizeInventory handles object', async () => {
+  const { normalizeInventory } = await import('../src/utils/inventoryUtils.js');
+  const input = { one: { item: 'sword' }, two: { item: 'shield' } };
+  const result = normalizeInventory(input);
+  expect(result).toEqual({ type: 'object', items: [['one', input.one], ['two', input.two]] });
+});
+
+test('normalizeInventory handles invalid', async () => {
+  const { normalizeInventory } = await import('../src/utils/inventoryUtils.js');
+  const result = normalizeInventory(null);
+  expect(result).toEqual({ type: 'empty', items: [] });
+});


### PR DESCRIPTION
## Summary
- handle arrays, objects and fallbacks in `CharacterCard` and `PlayerCard`
- add shared inventory normalization helper
- test helper for array/object/invalid inputs

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68581c38250c8322b7b9040b4bd6caa2