### PR TITLE
Implement translateOrRaw helper for character i18n

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { normalizeInventory } from '../utils/inventoryUtils';
+import { translateOrRaw } from '../utils/i18nHelpers';
 
 function translateEffect(effectString, t) {
   return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
     const key = stat.toLowerCase();
-    return `+${num} ${t('stats.' + key, t('unknown'))}`;
+    return `+${num} ${translateOrRaw(t, 'stats.' + key)}`;
   });
 }
 
@@ -27,19 +28,16 @@ export default function CharacterCard({ character }) {
       <h3>{character.name}</h3>
       <p>
 
-        {t(`races.${raceKey}`, t('unknown'))}
+        {translateOrRaw(t, `races.${raceKey}`)}
 
       </p>
       <p>
-        {t(
-          `classes.${classKey}`,
-          t('unknown')
-        )}
+        {translateOrRaw(t, `classes.${classKey}`)}
       </p>
       <ul>
         {Object.entries(character.stats || {}).map(([key, value]) => (
           <li key={key}>
-            {t(`stats.${key.toLowerCase()}`, t('unknown'))}: {value}
+            {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
           </li>
         ))}
       </ul>
@@ -54,7 +52,7 @@ export default function CharacterCard({ character }) {
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                         .join(', ') +
                       ')'
                   : '';
@@ -75,7 +73,7 @@ export default function CharacterCard({ character }) {
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                         .join(', ') +
                       ')'
                   : '';

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -5,11 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { getClassBorderColor } from '../utils/classColors';
 import Modal from './Modal';
 import { normalizeInventory } from '../utils/inventoryUtils';
+import { translateOrRaw } from '../utils/i18nHelpers';
 
 function translateEffect(effectString, t) {
   return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
     const key = stat.toLowerCase();
-    return `+${num} ${t('stats.' + key, t('unknown'))}`;
+    return `+${num} ${translateOrRaw(t, 'stats.' + key)}`;
   });
 }
 
@@ -48,8 +49,8 @@ export default function PlayerCard({ character, onSelect }) {
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
 
-          {t(`races.${raceKey}`, t('unknown'))}{' '}/{' '}
-          {t(`classes.${classKey}`, t('unknown'))}
+          {translateOrRaw(t, `races.${raceKey}`)}{' '}/{' '}
+          {translateOrRaw(t, `classes.${classKey}`)}
 
         </p>
         <button
@@ -71,9 +72,9 @@ export default function PlayerCard({ character, onSelect }) {
         <h3 className="text-lg text-dndgold text-center mb-2">{character.name}</h3>
         {character.stats && (
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
-            {Object.entries(character.stats).map(([key, val]) => (
+              {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {t(`stats.${key.toLowerCase()}`, t('unknown'))}: {val}
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {val}
               </li>
             ))}
           </ul>
@@ -89,7 +90,7 @@ export default function PlayerCard({ character, onSelect }) {
                       ?
                           ' (' +
                           Object.entries(it.bonus)
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                             .join(', ') +
                           ')'
                       : '';
@@ -114,7 +115,7 @@ export default function PlayerCard({ character, onSelect }) {
                       ?
                           ' (' +
                           Object.entries(it.bonus)
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                             .join(', ') +
                           ')'
                       : '';

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import api from "../api/axios";
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next';
+import { translateOrRaw } from '../utils/i18nHelpers';
 
 export default function CharacterListPage() {
   const [characters, setCharacters] = useState([]);
@@ -24,7 +25,7 @@ export default function CharacterListPage() {
               ? c.race.code
               : c.race?.en || '';
           const raceText = raceVal
-            ? t(`races.${raceVal.toLowerCase()}`, raceVal)
+            ? translateOrRaw(t, `races.${raceVal.toLowerCase()}`)
             : c.race?.name || t('unknown');
 
           const classVal =
@@ -34,7 +35,7 @@ export default function CharacterListPage() {
               ? c.profession.code
               : c.profession?.en || '';
           const classText = classVal
-            ? t(`classes.${classVal.toLowerCase()}`, classVal)
+            ? translateOrRaw(t, `classes.${classVal.toLowerCase()}`)
             : c.profession?.name || t('unknown');
 
           return (

--- a/frontend/src/utils/i18nHelpers.js
+++ b/frontend/src/utils/i18nHelpers.js
@@ -1,0 +1,4 @@
+export const translateOrRaw = (t, key) => {
+  const value = t(key);
+  return value === key ? key : value;
+};


### PR DESCRIPTION
## Summary
- add `translateOrRaw` helper for translations
- use new helper in CharacterCard, PlayerCard and CharacterListPage
- fall back to raw stat names when translation not found

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858212d7afc8322996f210920bfa595