### PR TITLE
Fix bonus checks in inventory rendering

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -9,6 +9,11 @@ function translateEffect(effectString, t) {
   });
 }
 
+function translateOrRaw(t, key) {
+  const translated = t(key);
+  return translated === key ? key.split('.').pop() : translated;
+}
+
 export default function CharacterCard({ character }) {
   const { t } = useTranslation();
   const race =
@@ -49,12 +54,14 @@ export default function CharacterCard({ character }) {
           const inv = normalizeInventory(character.inventory);
           if (inv.type === 'array' && inv.items.length > 0) {
             return inv.items.map((it, idx) => {
-              const bonus =
-                it.bonus && Object.keys(it.bonus).length
+              const bonusData =
+                it.bonus &&
+                typeof it.bonus === 'object' &&
+                Object.keys(it.bonus).length
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                         .join(', ') +
                       ')'
                   : '';
@@ -62,7 +69,7 @@ export default function CharacterCard({ character }) {
                 <li key={idx}>
                   {it.item}
                   {it.amount > 1 ? ` x${it.amount}` : ''}
-                  {bonus}
+                  {bonusData}
                   {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
                 </li>
               );
@@ -70,12 +77,14 @@ export default function CharacterCard({ character }) {
           }
           if (inv.type === 'object' && inv.items.length > 0) {
             return inv.items.map(([key, it]) => {
-              const bonus =
-                it.bonus && Object.keys(it.bonus).length
+              const bonusData =
+                it.bonus &&
+                typeof it.bonus === 'object' &&
+                Object.keys(it.bonus).length
                   ?
                       ' (' +
                       Object.entries(it.bonus)
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                         .join(', ') +
                       ')'
                   : '';
@@ -83,7 +92,7 @@ export default function CharacterCard({ character }) {
                 <li key={key}>
                   {it.item}
                   {it.amount > 1 ? ` x${it.amount}` : ''}
-                  {bonus}
+                  {bonusData}
                   {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
                 </li>
               );

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -13,6 +13,11 @@ function translateEffect(effectString, t) {
   });
 }
 
+function translateOrRaw(t, key) {
+  const translated = t(key);
+  return translated === key ? key.split('.').pop() : translated;
+}
+
 export default function PlayerCard({ character, onSelect }) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
@@ -84,12 +89,14 @@ export default function PlayerCard({ character, onSelect }) {
             return (
               <ul className="list-disc pl-4 mt-2 space-y-0.5">
                 {inv.items.map((it, idx) => {
-                  const bonus =
-                    it.bonus && Object.keys(it.bonus).length
+                  const bonusData =
+                    it.bonus &&
+                    typeof it.bonus === 'object' &&
+                    Object.keys(it.bonus).length
                       ?
                           ' (' +
                           Object.entries(it.bonus)
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                             .join(', ') +
                           ')'
                       : '';
@@ -97,7 +104,7 @@ export default function PlayerCard({ character, onSelect }) {
                     <li key={idx}>
                       {it.item}
                       {it.amount > 1 ? ` x${it.amount}` : ''}
-                      {bonus}
+                      {bonusData}
                       {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
                     </li>
                   );
@@ -109,12 +116,14 @@ export default function PlayerCard({ character, onSelect }) {
             return (
               <ul className="list-disc pl-4 mt-2 space-y-0.5">
                 {inv.items.map(([key, it]) => {
-                  const bonus =
-                    it.bonus && Object.keys(it.bonus).length
+                  const bonusData =
+                    it.bonus &&
+                    typeof it.bonus === 'object' &&
+                    Object.keys(it.bonus).length
                       ?
                           ' (' +
                           Object.entries(it.bonus)
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${t('stats.' + k.toLowerCase(), t('unknown'))}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
                             .join(', ') +
                           ')'
                       : '';
@@ -122,7 +131,7 @@ export default function PlayerCard({ character, onSelect }) {
                     <li key={key}>
                       {it.item}
                       {it.amount > 1 ? ` x${it.amount}` : ''}
-                      {bonus}
+                      {bonusData}
                       {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
                     </li>
                   );


### PR DESCRIPTION
## Summary
- add `translateOrRaw` helper
- improve inventory bonus detection for arrays and objects

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6858212e8630832289b941f255739819