### PR TITLE
Fix race/class key null safety

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -15,12 +15,12 @@ export default function CharacterCard({ character }) {
     typeof character.race === 'string'
       ? character.race
       : character.race?.code || character.race?.en || '';
-  const raceKey = race.toLowerCase();
+  const raceKey = (race || '').toLowerCase();
   const charClass =
     typeof character.profession === 'string'
       ? character.profession
       : character.profession?.code || character.profession?.en || '';
-  const classKey = charClass.toLowerCase();
+  const classKey = (charClass || '').toLowerCase();
 
   return (
     <div className='character-card'>

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -24,13 +24,13 @@ export default function PlayerCard({ character, onSelect }) {
     typeof character.race === 'string'
       ? character.race
       : character.race?.code || character.race?.en || '';
-  const raceKey = race.toLowerCase();
+  const raceKey = (race || '').toLowerCase();
 
   const charClass =
     typeof character.profession === 'string'
       ? character.profession
       : character.profession?.code || character.profession?.en || '';
-  const classKey = charClass.toLowerCase();
+  const classKey = (charClass || '').toLowerCase();
 
   return (
     <>

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -23,8 +23,9 @@ export default function CharacterListPage() {
               : typeof c.race?.code === 'string'
               ? c.race.code
               : c.race?.en || '';
+          const raceKey = (raceVal || '').toLowerCase();
           const raceText = raceVal
-            ? t(`races.${raceVal.toLowerCase()}`, raceVal)
+            ? t(`races.${raceKey}`, raceVal)
             : c.race?.name || t('unknown');
 
           const classVal =
@@ -33,8 +34,9 @@ export default function CharacterListPage() {
               : typeof c.profession?.code === 'string'
               ? c.profession.code
               : c.profession?.en || '';
+          const classKey = (classVal || '').toLowerCase();
           const classText = classVal
-            ? t(`classes.${classVal.toLowerCase()}`, classVal)
+            ? t(`classes.${classKey}`, classVal)
             : c.profession?.name || t('unknown');
 
           return (

--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -8,8 +8,7 @@ export function getClassBorderColor(profession) {
     healer: 'border-teal-600',
     druid: 'border-green-700',
   };
-  if (typeof profession !== 'string' || profession.trim() === '')
-    return 'border-dndgold';
-  const key = profession.toLowerCase();
+  const key = (profession || '').toLowerCase();
+  if (!key) return 'border-dndgold';
   return map[key] || 'border-dndgold';
 }


### PR DESCRIPTION
## Summary
- avoid calling `toLowerCase()` on undefined race or class values
- use the same fallback approach in CharacterListPage
- update classColors utility to handle missing profession

## Testing
- `npm test` *(fails: normalizeInventory requires experimental-vm-modules)*
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68582131639083228dfac4af03578497