### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ npm start
 
 ## Running tests
 
-Both the backend and frontend use **Jest**. Ensure dependencies are installed in
-each directory (run `./setup.sh` if you haven't already) and then execute:
+Both the backend and frontend use **Jest**. Install dependencies in each
+directory with `npm install` (or run the helper script `./setup.sh`) before
+running the tests.  The frontend tests rely on Node's experimental VM modules
+feature, so set `NODE_OPTIONS=--experimental-vm-modules` when invoking `npm
+test` there.  Then execute:
 
 ```bash
 cd backend && npm test


### PR DESCRIPTION
## Summary
- clarify that `npm install` must be run before tests
- mention `NODE_OPTIONS=--experimental-vm-modules` for frontend tests

## Testing
- `npm install` in `backend`
- `npm install` in `frontend`
- `NODE_OPTIONS=--experimental-vm-modules npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68582135741883229927d4586389f987