### PR TITLE
Fix translate helper conflict

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -14,7 +14,7 @@ function translateEffect(effectString, t) {
   });
 }
 
-function translateOrRaw(t, key) {
+function translateKey(t, key) {
   const translated = t(key);
   return translated === key ? key.split('.').pop() : translated;
 }
@@ -37,16 +37,16 @@ export default function CharacterCard({ character }) {
       <h3>{character.name}</h3>
       <p>
 
-        {translateOrRaw(t, `races.${raceKey}`)}
+        {translateKey(t, `races.${raceKey}`)}
 
       </p>
       <p>
-        {translateOrRaw(t, `classes.${classKey}`)}
+        {translateKey(t, `classes.${classKey}`)}
       </p>
       <ul>
         {Object.entries(character.stats || {}).map(([key, value]) => (
           <li key={key}>
-            {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
+            {translateKey(t, `stats.${key.toLowerCase()}`)}: {value}
           </li>
         ))}
       </ul>
@@ -64,7 +64,7 @@ export default function CharacterCard({ character }) {
                       ' (' +
                       Object.entries(it.bonus)
 
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
 
                         .join(', ') +
                       ')'
@@ -72,7 +72,7 @@ export default function CharacterCard({ character }) {
               return (
                 <li key={idx}>
 
-                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                  {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                   {it.amount > 1 ? ` x${it.amount}` : ''}
                   {bonusData}
@@ -91,14 +91,14 @@ export default function CharacterCard({ character }) {
                       ' (' +
                       Object.entries(it.bonus)
 
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
            .join(', ') +
                       ')'
                   : '';
               return (
                 <li key={key}>
 
-                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                  {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                   {it.amount > 1 ? ` x${it.amount}` : ''}
                   {bonusData}

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -18,7 +18,7 @@ function translateEffect(effectString, t) {
   });
 }
 
-function translateOrRaw(t, key) {
+function translateKey(t, key) {
   const translated = t(key);
   return translated === key ? key.split('.').pop() : translated;
 }
@@ -58,8 +58,8 @@ export default function PlayerCard({ character, onSelect }) {
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
 
-          {translateOrRaw(t, `races.${raceKey}`)}{' '}/{' '}
-          {translateOrRaw(t, `classes.${classKey}`)}
+          {translateKey(t, `races.${raceKey}`)}{' '}/{' '}
+          {translateKey(t, `classes.${classKey}`)}
 
         </p>
         <button
@@ -83,7 +83,7 @@ export default function PlayerCard({ character, onSelect }) {
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
               {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {val}
+                {translateKey(t, `stats.${key.toLowerCase()}`)}: {val}
               </li>
             ))}
           </ul>
@@ -102,7 +102,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
 
                             .join(', ') +
                           ')'
@@ -110,7 +110,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={idx}>
 
-                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}
@@ -133,7 +133,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
 
                             .join(', ') +
                           ')'
@@ -141,7 +141,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={key}>
 
-                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}


### PR DESCRIPTION
## Summary
- rename local `translateOrRaw` helpers to `translateKey`
- update component code to use `translateKey`
- keep imported `translateOrRaw` helper for effect translation
- verify frontend build with Vite

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68582960ab548322996e82b420bd7d32