### PR TITLE
Simplify frontend test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,8 @@ npm start
 
 Both the backend and frontend use **Jest**. Install dependencies in each
 directory with `npm install` (or run the helper script `./setup.sh`) before
-running the tests.  The frontend tests rely on Node's experimental VM modules
-feature, so set `NODE_OPTIONS=--experimental-vm-modules` when invoking `npm
-test` there.  Then execute:
+running the tests. The frontend test script now sets the required Node option
+automatically using `cross-env`, so simply run:
 
 ```bash
 cd backend && npm test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.14",
+        "cross-env": "^7.0.3",
         "jest": "^29.7.0",
         "postcss": "^8.4.24",
         "socket.io": "^4.8.1",
@@ -3010,6 +3011,25 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,12 +8,13 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "npx serve -s build",
-    "test": "jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "axios": "^1.6.0",
     "chart.js": "^4.4.9",
     "clsx": "^2.1.0",
+    "dompurify": "^3.2.6",
     "framer-motion": "^11.0.0",
     "i18next": "^23.0.1",
     "lucide-react": "^0.346.0",
@@ -26,8 +27,7 @@
     "react-player": "^2.12.0",
     "react-router-dom": "^6.30.1",
     "socket.io-client": "^4.7.5",
-    "zustand": "^4.5.2",
-    "dompurify": "^3.2.6"
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -36,6 +36,7 @@
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.14",
+    "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "postcss": "^8.4.24",
     "socket.io": "^4.8.1",


### PR DESCRIPTION
## Summary
- add `cross-env` dev dependency
- streamline `npm test` script to set `NODE_OPTIONS`
- mention the simplified test command in README

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68582961a4e88322b07c1215e1be468a