### PR TITLE
Create shared translateEffect util

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -3,21 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { normalizeInventory } from '../utils/inventoryUtils';
 
 import translateOrRaw from '../utils/translateOrRaw.js';
-
-
-function translateEffect(effectString, t) {
-  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
-    const key = stat.toLowerCase();
-
-    return `+${num} ${translateOrRaw(t, 'stats.' + key)}`;
-
-  });
-}
-
-function translateOrRaw(t, key) {
-  const translated = t(key);
-  return translated === key ? key.split('.').pop() : translated;
-}
+import translateEffect from '../utils/effectUtils.js';
 
 export default function CharacterCard({ character }) {
   const { t } = useTranslation();

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -1,15 +1,7 @@
 
 import { useTranslation } from 'react-i18next';
 import translateOrRaw from '../utils/translateOrRaw.js';
-
-function translateEffect(effectString, t) {
-  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
-    const key = stat.toLowerCase();
-
-    return `+${num} ${translateOrRaw(t, 'stats.' + key, stat)}`;
-
-  });
-}
+import translateEffect from '../utils/effectUtils.js';
 
 export default function InventoryList({ items, filter = 'all' }) {
   const { t } = useTranslation();

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -7,21 +7,7 @@ import Modal from './Modal';
 import { normalizeInventory } from '../utils/inventoryUtils';
 
 import translateOrRaw from '../utils/translateOrRaw.js';
-
-
-function translateEffect(effectString, t) {
-  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
-    const key = stat.toLowerCase();
-
-    return `+${num} ${translateOrRaw(t, 'stats.' + key)}`;
-
-  });
-}
-
-function translateOrRaw(t, key) {
-  const translated = t(key);
-  return translated === key ? key.split('.').pop() : translated;
-}
+import translateEffect from '../utils/effectUtils.js';
 
 export default function PlayerCard({ character, onSelect }) {
   const [open, setOpen] = useState(false);

--- a/frontend/src/utils/effectUtils.js
+++ b/frontend/src/utils/effectUtils.js
@@ -1,0 +1,9 @@
+import translateOrRaw from './translateOrRaw.js';
+
+export default function translateEffect(effectString, t) {
+  if (!effectString) return effectString;
+  return effectString.replace(/\+(\d+)\s([A-Z]+)/g, (_, num, stat) => {
+    const key = stat.toLowerCase();
+    return `+${num} ${translateOrRaw(t, 'stats.' + key, stat)}`;
+  });
+}


### PR DESCRIPTION
## Summary
- centralize effect translation to new `effectUtils` module
- update InventoryList, CharacterCard and PlayerCard to use the shared logic

## Testing
- `npm run build` in `frontend`
- `NODE_OPTIONS=--experimental-vm-modules npm test` in `frontend`
- `npm test` in `backend` *(fails: start-game notifies all lobby members)*

------
https://chatgpt.com/codex/tasks/task_e_68582961d7988322826a24389c86ff9b