### PR TITLE
Fix translation helper references

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -29,16 +29,16 @@ export default function CharacterCard({ character }) {
       <h3>{character.name}</h3>
       <p>
 
-        {translateKey(t, `races.${raceKey}`)}
+        {translateOrRaw(t, `races.${raceKey}`)}
 
       </p>
       <p>
-        {translateKey(t, `classes.${classKey}`)}
+        {translateOrRaw(t, `classes.${classKey}`)}
       </p>
       <ul>
         {Object.entries(character.stats || {}).map(([key, value]) => (
           <li key={key}>
-            {translateKey(t, `stats.${key.toLowerCase()}`)}: {value}
+            {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
           </li>
         ))}
       </ul>
@@ -56,7 +56,7 @@ export default function CharacterCard({ character }) {
                       ' (' +
                       Object.entries(it.bonus)
 
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
 
                         .join(', ') +
                       ')'
@@ -64,7 +64,7 @@ export default function CharacterCard({ character }) {
               return (
                 <li key={idx}>
 
-                  {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                   {it.amount > 1 ? ` x${it.amount}` : ''}
                   {bonusData}
@@ -83,14 +83,14 @@ export default function CharacterCard({ character }) {
                       ' (' +
                       Object.entries(it.bonus)
 
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
+                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
            .join(', ') +
                       ')'
                   : '';
               return (
                 <li key={key}>
 
-                  {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                   {it.amount > 1 ? ` x${it.amount}` : ''}
                   {bonusData}

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -46,8 +46,8 @@ export default function PlayerCard({ character, onSelect }) {
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
 
-          {translateKey(t, `races.${raceKey}`)}{' '}/{' '}
-          {translateKey(t, `classes.${classKey}`)}
+          {translateOrRaw(t, `races.${raceKey}`)}{' '}/{' '}
+          {translateOrRaw(t, `classes.${classKey}`)}
 
         </p>
         <button
@@ -71,7 +71,7 @@ export default function PlayerCard({ character, onSelect }) {
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
               {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {translateKey(t, `stats.${key.toLowerCase()}`)}: {val}
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {val}
               </li>
             ))}
           </ul>
@@ -90,7 +90,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
 
                             .join(', ') +
                           ')'
@@ -98,7 +98,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={idx}>
 
-                      {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}
@@ -121,7 +121,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateKey(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
 
                             .join(', ') +
                           ')'
@@ -129,7 +129,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={key}>
 
-                      {translateKey(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}


### PR DESCRIPTION
## Summary
- replace legacy `translateKey` calls with `translateOrRaw`
- keep components free of unused imports

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68582e331ed083228994d3ac130a47c3