### PR TITLE
Fix CharacterCard layout

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -1,18 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { normalizeInventory } from '../utils/inventoryUtils';
-
+import { withApiHost } from '../utils/imageUtils';
+import Modal from './Modal';
 import translateOrRaw from '../utils/translateOrRaw.js';
-
 import translateEffect from '../utils/effectUtils.js';
 
-
-
-
-
-
-export default function CharacterCard({ character }) {
+export default function CharacterCard({
+  character,
+  editLabel,
+  onEdit,
+  onDelete,
+  onSaveDescription,
+}) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [desc, setDesc] = useState(character.description || '');
   const race =
     typeof character.race === 'string'
       ? character.race
@@ -25,83 +28,132 @@ export default function CharacterCard({ character }) {
   const classKey = (charClass || '').toLowerCase();
 
   return (
-    <div className="card">
-      <h3>{character.name}</h3>
-      <p>
-
-        {translateOrRaw(t, `races.${raceKey}`)}
-
-      </p>
-      <p>
-        {translateOrRaw(t, `classes.${classKey}`)}
-      </p>
-      <ul>
-        {Object.entries(character.stats || {}).map(([key, value]) => (
-          <li key={key}>
-            {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
-          </li>
-        ))}
-      </ul>
-      <h4>{t('inventory.title')}</h4>
-      <ul>
-        {(() => {
-          const inv = normalizeInventory(character.inventory);
-          if (inv.type === 'array' && inv.items.length > 0) {
-            return inv.items.map((it, idx) => {
-              const bonusData =
-                it.bonus &&
-                typeof it.bonus === 'object' &&
-                Object.keys(it.bonus).length
-                  ?
-                      ' (' +
-                      Object.entries(it.bonus)
-
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
-
-                        .join(', ') +
-                      ')'
-                  : '';
-              return (
-                <li key={idx}>
-
-                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
-
-                  {it.amount > 1 ? ` x${it.amount}` : ''}
-                  {bonusData}
-                  {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
-                </li>
-              );
-            });
-          }
-          if (inv.type === 'object' && inv.items.length > 0) {
-            return inv.items.map(([key, it]) => {
-              const bonusData =
-                it.bonus &&
-                typeof it.bonus === 'object' &&
-                Object.keys(it.bonus).length
-                  ?
-                      ' (' +
-                      Object.entries(it.bonus)
-
-                        .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
-           .join(', ') +
-                      ')'
-                  : '';
-              return (
-                <li key={key}>
-
-                  {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
-
-                  {it.amount > 1 ? ` x${it.amount}` : ''}
-                  {bonusData}
-                  {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
-                </li>
-              );
-            });
-          }
-          return <li>{t('inventory.empty')}</li>;
-        })()}
-      </ul>
-    </div>
+    <>
+      <div className="card max-w-[400px] flex flex-col items-center">
+        <img
+          src={withApiHost(character.image) || '/default-avatar.png'}
+          alt={character.name}
+          onError={(e) => (e.currentTarget.src = '/default-avatar.png')}
+          className="w-full h-40 object-cover rounded mb-2"
+        />
+        <h3 className="text-lg text-center text-dndgold mb-1">{character.name}</h3>
+        <p className="text-sm text-center mb-2">
+          {translateOrRaw(t, `races.${raceKey}`)} /{' '}
+          {translateOrRaw(t, `classes.${classKey}`)}
+        </p>
+        {character.description && (
+          <p className="text-sm italic mb-2 text-center">{character.description}</p>
+        )}
+        <div className="mt-auto flex flex-wrap justify-center gap-2">
+          {onEdit && (
+            <button
+              onClick={onEdit}
+              className="bg-dndgold text-dndred font-dnd rounded-2xl px-4 py-1 transition active:scale-95"
+            >
+              {editLabel || 'Редагувати'}
+            </button>
+          )}
+          {onDelete && (
+            <button
+              onClick={onDelete}
+              className="bg-red-800 hover:bg-red-700 text-white rounded-2xl px-4 py-1 transition active:scale-95"
+            >
+              Видалити
+            </button>
+          )}
+          <button
+            onClick={() => setOpen(true)}
+            className="bg-dndgold text-dndred font-dnd rounded-2xl px-4 py-1 transition active:scale-95"
+          >
+            Деталі
+          </button>
+        </div>
+      </div>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <h3 className="text-lg text-dndgold text-center mb-2">{character.name}</h3>
+        <p className="text-sm text-center mb-2">
+          {translateOrRaw(t, `races.${raceKey}`)} /{' '}
+          {translateOrRaw(t, `classes.${classKey}`)}
+        </p>
+        <textarea
+          className="w-full rounded-lg p-2 bg-[#2c1a12] border border-dndgold text-dndgold mb-2"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+        />
+        {onSaveDescription && (
+          <button
+            onClick={() => {
+              onSaveDescription(character._id, desc);
+              setOpen(false);
+            }}
+            className="mb-2 bg-dndgold text-dndred font-dnd rounded-2xl px-4 py-1 transition active:scale-95"
+          >
+            Зберегти
+          </button>
+        )}
+        {character.stats && (
+          <ul className="list-none pl-0 text-sm mb-2 space-y-0.5">
+            {Object.entries(character.stats).map(([key, value]) => (
+              <li key={key}>
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
+              </li>
+            ))}
+          </ul>
+        )}
+        <h4 className="text-dndgold mb-1">{t('inventory.title')}</h4>
+        <ul className="list-disc pl-4 text-sm space-y-0.5">
+          {(() => {
+            const inv = normalizeInventory(character.inventory);
+            if (inv.type === 'array' && inv.items.length > 0) {
+              return inv.items.map((it, idx) => {
+                const bonusData =
+                  it.bonus &&
+                  typeof it.bonus === 'object' &&
+                  Object.keys(it.bonus).length
+                    ?
+                        ' (' +
+                        Object.entries(it.bonus)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                          .join(', ') +
+                        ')'
+                    : '';
+                return (
+                  <li key={idx}>
+                    {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                    {it.amount > 1 ? ` x${it.amount}` : ''}
+                    {bonusData}
+                    {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                  </li>
+                );
+              });
+            }
+            if (inv.type === 'object' && inv.items.length > 0) {
+              return inv.items.map(([key, it]) => {
+                const bonusData =
+                  it.bonus &&
+                  typeof it.bonus === 'object' &&
+                  Object.keys(it.bonus).length
+                    ?
+                        ' (' +
+                        Object.entries(it.bonus)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                          .join(', ') +
+                        ')'
+                    : '';
+                return (
+                  <li key={key}>
+                    {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                    {it.amount > 1 ? ` x${it.amount}` : ''}
+                    {bonusData}
+                    {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                  </li>
+                );
+              });
+            }
+            return <li>{t('inventory.empty')}</li>;
+          })()}
+        </ul>
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,5 +23,5 @@ body {
 }
 
 .card {
-  @apply border rounded-lg p-4 bg-[#1c120a]/80 text-dndgold shadow-lg;
+  @apply border-2 rounded-lg p-4 bg-[#1c120a]/70 text-dndgold shadow-lg;
 }

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -59,7 +59,7 @@ const ProfilePage = () => {
       >
         Створити нового
       </button>
-      <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl">
+      <div className="w-full flex flex-wrap justify-center gap-4 max-w-5xl overflow-y-auto">
         {characters.length === 0 ? (
           <div className="col-span-full text-center text-dndgold/80">
             Тут поки пусто. Створи першого героя!


### PR DESCRIPTION
## Summary
- rework CharacterCard component: add modal for details and editing
- update card styling and max width
- adjust profile page layout to wrap and scroll
- tweak global `.card` style

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6858301fde308322be85f0fb529367c6