### PR TITLE
Fix missing race and class localization

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -16,16 +16,16 @@ export default function CharacterCard({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [desc, setDesc] = useState(character.description || '');
-  const race =
+  const raceKey =
     typeof character.race === 'string'
       ? character.race
-      : character.race?.code || character.race?.en || '';
-  const raceKey = (race || '').toLowerCase();
-  const charClass =
-    typeof character.profession === 'string'
-      ? character.profession
-      : character.profession?.code || character.profession?.en || '';
-  const classKey = (charClass || '').toLowerCase();
+      : character.race?.name || character.race?.code || '';
+  const classKey =
+    typeof character.class === 'string'
+      ? character.class
+      : character.class?.name || character.class?.code || '';
+  const raceKeyLower = (raceKey || '').toLowerCase();
+  const classKeyLower = (classKey || '').toLowerCase();
 
   return (
     <>
@@ -38,8 +38,8 @@ export default function CharacterCard({
         />
         <h3 className="text-lg text-center text-dndgold mb-1">{character.name}</h3>
         <p className="text-sm text-center mb-2">
-          {translateOrRaw(t, `races.${raceKey}`)} /{' '}
-          {translateOrRaw(t, `classes.${classKey}`)}
+          {translateOrRaw(t, `races.${raceKeyLower}`)} /{' '}
+          {translateOrRaw(t, `classes.${classKeyLower}`)}
         </p>
         {character.description && (
           <p className="text-sm italic mb-2 text-center">{character.description}</p>
@@ -72,8 +72,8 @@ export default function CharacterCard({
       <Modal open={open} onClose={() => setOpen(false)}>
         <h3 className="text-lg text-dndgold text-center mb-2">{character.name}</h3>
         <p className="text-sm text-center mb-2">
-          {translateOrRaw(t, `races.${raceKey}`)} /{' '}
-          {translateOrRaw(t, `classes.${classKey}`)}
+          {translateOrRaw(t, `races.${raceKeyLower}`)} /{' '}
+          {translateOrRaw(t, `classes.${classKeyLower}`)}
         </p>
         <textarea
           className="w-full rounded-lg p-2 bg-[#2c1a12] border border-dndgold text-dndgold mb-2"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -23,7 +23,8 @@
     "elf": "Elf",
     "orc": "Orc",
     "gnome": "Gnome",
-    "dwarf": "Dwarf"
+    "dwarf": "Dwarf",
+    "lizardman": "Lizardman"
   },
   "classes": {
     "warrior": "Warrior",
@@ -31,7 +32,8 @@
     "archer": "Archer",
     "paladin": "Paladin",
     "bard": "Bard",
-    "healer": "Healer"
+    "healer": "Healer",
+    "rogue": "Rogue"
   },
   "stats": {
     "health": "Health",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -23,7 +23,8 @@
     "elf": "Ельф",
     "orc": "Орк",
     "gnome": "Гном",
-    "dwarf": "Дварф"
+    "dwarf": "Дварф",
+    "lizardman": "Ящірка"
   },
   "classes": {
     "warrior": "Воїн",
@@ -31,7 +32,8 @@
     "archer": "Лучник",
     "paladin": "Паладин",
     "bard": "Бард",
-    "healer": "Лікар"
+    "healer": "Цілитель",
+    "rogue": "Шпигун"
   },
   "stats": {
     "health": "Здоров'я",


### PR DESCRIPTION
## Summary
- support `character.class` prop in `CharacterCard`
- localize lizardman and rogue options
- fix Ukrainian label for healer

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858333f26308322b4fdd9816bd8ccc0