### PR TITLE
Configure Vite build chunks

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,22 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/',
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 1024,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('i18next') || id.includes('react-i18next')) {
+              return 'i18n';
+            }
+            if (id.includes('react') || id.includes('react-dom')) {
+              return 'react';
+            }
+            return 'vendor';
+          }
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- tweak Vite build to set a custom chunk warning limit
- split vendor chunks: react, i18n, and general vendor

## Testing
- `./setup.sh`
- `npm test` in `backend` *(fails: start-game notifies all lobby members)*
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685835ee78188322ac3bffb1f0af62f5