### PR TITLE
Implement lazy loading for pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import LoginPage from './pages/LoginPage';
-import RegisterPage from './pages/RegisterPage';
-import ProfilePage from './pages/ProfilePage';
-import CharacterCreatePage from './pages/CharacterCreatePage';
-import LobbyPage from './pages/LobbyPage';
-import AdminPage from './pages/AdminPage';
-import AdminInventoryPage from './pages/admin/AdminInventoryPage';
-import AdminUsersPage from './pages/admin/AdminUsersPage';
-import ChangePasswordPage from './pages/ChangePasswordPage';
-import GameTablePage from './pages/GameTablePage';
-import GMTablePage from './pages/gm/GMTablePage';
-import AdminLoginPage from './pages/AdminLoginPage';
-import SettingsPanel from './pages/SettingsPanel';
+import Loader from './components/Loader';
 
-import GMDashboard from './pages/GMDashboard';
-import GMControlPage from './pages/gm/GMControlPage';
+const LoginPage = React.lazy(() => import('./pages/LoginPage'));
+const RegisterPage = React.lazy(() => import('./pages/RegisterPage'));
+const ProfilePage = React.lazy(() => import('./pages/ProfilePage'));
+const CharacterCreatePage = React.lazy(() => import('./pages/CharacterCreatePage'));
+const LobbyPage = React.lazy(() => import('./pages/LobbyPage'));
+const AdminPage = React.lazy(() => import('./pages/AdminPage'));
+const AdminInventoryPage = React.lazy(() => import('./pages/admin/AdminInventoryPage'));
+const AdminUsersPage = React.lazy(() => import('./pages/admin/AdminUsersPage'));
+const ChangePasswordPage = React.lazy(() => import('./pages/ChangePasswordPage'));
+const GameTablePage = React.lazy(() => import('./pages/GameTablePage'));
+const GMTablePage = React.lazy(() => import('./pages/gm/GMTablePage'));
+const AdminLoginPage = React.lazy(() => import('./pages/AdminLoginPage'));
+const SettingsPanel = React.lazy(() => import('./pages/SettingsPanel'));
+
+const GMDashboard = React.lazy(() => import('./pages/GMDashboard'));
+const GMControlPage = React.lazy(() => import('./pages/gm/GMControlPage'));
 
 import PrivateRoute from './PrivateRoute';
 import useKeepAlive from './hooks/useKeepAlive';
@@ -47,6 +49,7 @@ const homeRoute = () => {
 const App = () => {
   useKeepAlive();
   return (
+    <React.Suspense fallback={<Loader />}>
     <Routes>
       <Route path="/" element={<Navigate to={homeRoute()} />} />
       <Route path="/login" element={<LoginPage />} />
@@ -72,6 +75,7 @@ const App = () => {
 
     <Route path="*" element={<Navigate to="/" />} />
   </Routes>
+    </React.Suspense>
   );
 };
 

--- a/frontend/src/components/Loader.jsx
+++ b/frontend/src/components/Loader.jsx
@@ -1,0 +1,5 @@
+export default function Loader() {
+  return (
+    <div className="text-center p-4">Loading...</div>
+  );
+}

--- a/frontend/src/routes/AdminRoutes.jsx
+++ b/frontend/src/routes/AdminRoutes.jsx
@@ -1,21 +1,25 @@
-import {
-  AdminRacesPage,
-  AdminProfessionsPage,
-  AdminCharacteristicsPage,
-  AdminMapsPage,
-  AdminMusicPage,
-  AdminInventoryPage,
-} from '../pages/admin';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Loader from '../components/Loader';
+
+const AdminRacesPage = React.lazy(() => import('../pages/admin/AdminRacesPage'));
+const AdminProfessionsPage = React.lazy(() => import('../pages/admin/AdminProfessionsPage'));
+const AdminCharacteristicsPage = React.lazy(() => import('../pages/admin/AdminCharacteristicsPage'));
+const AdminMapsPage = React.lazy(() => import('../pages/admin/AdminMapsPage'));
+const AdminMusicPage = React.lazy(() => import('../pages/admin/AdminMusicPage'));
+const AdminInventoryPage = React.lazy(() => import('../pages/admin/AdminInventoryPage'));
 
 export default function AdminRoutes() {
   return (
-    <Routes>
-      <Route path="races" element={<AdminRacesPage />} />
-      <Route path="professions" element={<AdminProfessionsPage />} />
-      <Route path="characteristics" element={<AdminCharacteristicsPage />} />
-      <Route path="maps" element={<AdminMapsPage />} />
-      <Route path="music" element={<AdminMusicPage />} />
-      <Route path="inventory/:characterId" element={<AdminInventoryPage />} />
-    </Routes>
+    <React.Suspense fallback={<Loader />}>
+      <Routes>
+        <Route path="races" element={<AdminRacesPage />} />
+        <Route path="professions" element={<AdminProfessionsPage />} />
+        <Route path="characteristics" element={<AdminCharacteristicsPage />} />
+        <Route path="maps" element={<AdminMapsPage />} />
+        <Route path="music" element={<AdminMusicPage />} />
+        <Route path="inventory/:characterId" element={<AdminInventoryPage />} />
+      </Routes>
+    </React.Suspense>
   );
 }

--- a/frontend/src/routes/UserRoutes.jsx
+++ b/frontend/src/routes/UserRoutes.jsx
@@ -1,13 +1,19 @@
-import CharacterListPage from '../pages/CharacterListPage';
-import CharacterCreatePage from '../pages/CharacterCreatePage';
-import CharacterEditPage from '../pages/CharacterEditPage';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Loader from '../components/Loader';
+
+const CharacterListPage = React.lazy(() => import('../pages/CharacterListPage'));
+const CharacterCreatePage = React.lazy(() => import('../pages/CharacterCreatePage'));
+const CharacterEditPage = React.lazy(() => import('../pages/CharacterEditPage'));
 
 export default function UserRoutes() {
   return (
-    <Routes>
-      <Route path="characters" element={<CharacterListPage />} />
-      <Route path="characters/new" element={<CharacterCreatePage />} />
-      <Route path="characters/:id/edit" element={<CharacterEditPage />} />
-    </Routes>
+    <React.Suspense fallback={<Loader />}>
+      <Routes>
+        <Route path="characters" element={<CharacterListPage />} />
+        <Route path="characters/new" element={<CharacterCreatePage />} />
+        <Route path="characters/:id/edit" element={<CharacterEditPage />} />
+      </Routes>
+    </React.Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- lazy-load App pages with `React.lazy`
- add simple `Loader` component
- wrap `Routes` with `React.Suspense`
- convert route files to lazy imports

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685835f0a44883228d6c1c584797878f