### PR TITLE
Fix translation fallback for character info

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -38,8 +38,8 @@ export default function CharacterCard({
         />
         <h3 className="text-lg text-center text-dndgold mb-1">{character.name}</h3>
         <p className="text-sm text-center mb-2">
-          {translateOrRaw(t, `races.${raceKeyLower}`)} /{' '}
-          {translateOrRaw(t, `classes.${classKeyLower}`)}
+          {translateOrRaw(t, `races.${raceKeyLower}`, raceKey)} /{' '}
+          {translateOrRaw(t, `classes.${classKeyLower}`, classKey)}
         </p>
         {character.description && (
           <p className="text-sm italic mb-2 text-center">{character.description}</p>
@@ -72,8 +72,8 @@ export default function CharacterCard({
       <Modal open={open} onClose={() => setOpen(false)}>
         <h3 className="text-lg text-dndgold text-center mb-2">{character.name}</h3>
         <p className="text-sm text-center mb-2">
-          {translateOrRaw(t, `races.${raceKeyLower}`)} /{' '}
-          {translateOrRaw(t, `classes.${classKeyLower}`)}
+          {translateOrRaw(t, `races.${raceKeyLower}`, raceKey)} /{' '}
+          {translateOrRaw(t, `classes.${classKeyLower}`, classKey)}
         </p>
         <textarea
           className="w-full rounded-lg p-2 bg-[#2c1a12] border border-dndgold text-dndgold mb-2"
@@ -95,7 +95,7 @@ export default function CharacterCard({
           <ul className="list-none pl-0 text-sm mb-2 space-y-0.5">
             {Object.entries(character.stats).map(([key, value]) => (
               <li key={key}>
-                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {value}
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`, key)}: {value}
               </li>
             ))}
           </ul>
@@ -113,7 +113,7 @@ export default function CharacterCard({
                     ?
                         ' (' +
                         Object.entries(it.bonus)
-                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
                           .join(', ') +
                         ')'
                     : '';
@@ -136,7 +136,7 @@ export default function CharacterCard({
                     ?
                         ' (' +
                         Object.entries(it.bonus)
-                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
                           .join(', ') +
                         ')'
                     : '';

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -46,8 +46,8 @@ export default function PlayerCard({ character, onSelect }) {
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">
 
-          {translateOrRaw(t, `races.${raceKey}`)}{' '}/{' '}
-          {translateOrRaw(t, `classes.${classKey}`)}
+          {translateOrRaw(t, `races.${raceKey}`, race)}{' '}/{' '}
+          {translateOrRaw(t, `classes.${classKey}`, charClass)}
 
         </p>
         <button
@@ -71,7 +71,7 @@ export default function PlayerCard({ character, onSelect }) {
           <ul className="list-none pl-0 text-lg font-bold space-y-0.5">
               {Object.entries(character.stats).map(([key, val]) => (
               <li key={key}>
-                {translateOrRaw(t, `stats.${key.toLowerCase()}`)}: {val}
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`, key)}: {val}
               </li>
             ))}
           </ul>
@@ -90,7 +90,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
 
                             .join(', ') +
                           ')'
@@ -121,7 +121,7 @@ export default function PlayerCard({ character, onSelect }) {
                           ' (' +
                           Object.entries(it.bonus)
 
-                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase())}`)
+                            .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
 
                             .join(', ') +
                           ')'


### PR DESCRIPTION
## Summary
- show raw race/class/stats text if translation key missing
- include raw fallback when listing stat bonuses

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6858363e1d388322954dcd2dcfb40ce5