### PR TITLE
Add hidden dice roller for GM

### DIFF
--- a/frontend/src/components/DiceRollerHidden.jsx
+++ b/frontend/src/components/DiceRollerHidden.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import api from "../api/axios";
+
+const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
+
+export default function DiceRollerHidden({ sessionId }) {
+  const [rolling, setRolling] = useState(false);
+  const [lastRoll, setLastRoll] = useState(null);
+
+  const rollDice = async (type) => {
+    setRolling(true);
+    try {
+      const res = await api.post("/rolls", {
+        diceType: type,
+        isPrivate: true,
+        session: sessionId,
+      });
+      setLastRoll(res.data.value ?? "???");
+    } catch (err) {
+      console.error("Hidden roll error:", err);
+    } finally {
+      setRolling(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="flex gap-3 mb-2">
+        {diceTypes.map((dt) => (
+          <button
+            key={dt}
+            onClick={() => rollDice(dt)}
+            disabled={rolling}
+            className={`bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-3 py-2 transition-all ${rolling ? 'opacity-60' : ''}`}
+          >
+            {dt}
+          </button>
+        ))}
+      </div>
+      {lastRoll !== null && (
+        <div className="text-dndgold text-lg font-dnd mt-1">
+          Результат: <b>{lastRoll}</b>
+        </div>
+      )}
+      <div className="text-xs text-dndgold/60 mt-2">
+        Кидок бачить лише майстер
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/gm/GMControlPage.jsx
+++ b/frontend/src/pages/gm/GMControlPage.jsx
@@ -5,6 +5,7 @@ import { useUserStore } from '../../store/user';
 import { GameStateProvider, useGameState } from '../../context/GameStateContext';
 import PlayerStatusTable from '../../components/PlayerStatusTable';
 import DiceBox from '../../components/DiceBox';
+import DiceRollerHidden from '../../components/DiceRollerHidden';
 import socket from '../../api/socket';
 
 function Control() {
@@ -65,6 +66,7 @@ function Control() {
       </div>
       <PlayerStatusTable players={players} isGM />
       <DiceBox />
+      <DiceRollerHidden sessionId={id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `DiceRollerHidden` component for private rolls
- show hidden dice roller on GM control page
- keep other dice box for local rolls

## Testing
- `cd backend && npm install && npm test`
- `cd ../frontend && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685839e028c083229d38e21e910f0016