### PR TITLE
Add missing locale strings

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -7,6 +7,9 @@
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",
   "unknown": "Unknown",
+  "create_table": "Create table",
+  "map_from_file": "Map from file",
+  "mp": "MP",
   "races": {
     "human_male": "Human (male)",
     "human_female": "Human (female)",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -7,6 +7,9 @@
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",
   "unknown": "Невідомо",
+  "create_table": "Створити стіл",
+  "map_from_file": "Карта з файлу",
+  "mp": "MP",
   "races": {
     "human_male": "Людина (чоловік)",
     "human_female": "Людина (жінка)",


### PR DESCRIPTION
## Summary
- add translation keys for new interface strings in `ua.json` and `en.json`

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685839e10d048322b3f83cb447b8deb8