### PR TITLE
Fix start script directory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "npx serve -s build",
+    "start": "npx serve -s dist",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- use `serve` on `dist` output folder

## Testing
- `./setup.sh`
- `npm test` in `backend` *(fails: start-game test timeout)*
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68584080a300832294e6f6da34f27101