### PR TITLE
Remove unused login redirect util

### DIFF
--- a/frontend/src/utils/getPostLoginRedirect.cjs
+++ b/frontend/src/utils/getPostLoginRedirect.cjs
@@ -1,5 +1,0 @@
-function getPostLoginRedirect(role) {
-  return role === 'gm' || role === 'admin' ? '/gm-dashboard' : '/characters';
-}
-
-module.exports = getPostLoginRedirect;

--- a/frontend/tests/loginRedirect.test.cjs
+++ b/frontend/tests/loginRedirect.test.cjs
@@ -1,8 +1,0 @@
-/** @jest-environment node */
-const getPostLoginRedirect = require('../src/utils/getPostLoginRedirect.cjs');
-
-test('gm role redirects to gm dashboard', () => {
-  expect(getPostLoginRedirect('gm')).toBe('/gm-dashboard');
-  expect(getPostLoginRedirect('admin')).toBe('/gm-dashboard');
-  expect(getPostLoginRedirect('player')).toBe('/characters');
-});


### PR DESCRIPTION
## Summary
- clean up unused `getPostLoginRedirect.cjs` util
- remove its associated test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858408182cc832287b97175fce52075