### PR TITLE
Fix asset paths for root hosting

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -31,9 +31,9 @@ export default function CharacterCard({
     <>
       <div className="card max-w-[400px] flex flex-col items-center">
         <img
-          src={withApiHost(character.image) || './default-avatar.png'}
+          src={withApiHost(character.image) || '/default-avatar.png'}
           alt={character.name}
-          onError={(e) => (e.currentTarget.src = './default-avatar.png')}
+          onError={(e) => (e.currentTarget.src = '/default-avatar.png')}
           className="w-full h-40 object-cover rounded mb-2"
         />
         <h3 className="text-lg text-center text-dndgold mb-1">{character.name}</h3>

--- a/frontend/src/components/DiceBox.jsx
+++ b/frontend/src/components/DiceBox.jsx
@@ -10,7 +10,7 @@ export default function DiceBox({ className = '' }) {
     setDiceResult(null);
     setDiceAnim(true);
 
-    const audio = new Audio('./dice.mp3');
+    const audio = new Audio('/dice.mp3');
     audio.play().catch(() => {});
 
     setTimeout(() => {

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -38,10 +38,10 @@ export default function PlayerCard({ character, onSelect }) {
         className={`border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd w-56 ${borderColor}`}
       >
         <img
-          src={withApiHost(character.image) || './default-avatar.png'}
+          src={withApiHost(character.image) || '/default-avatar.png'}
           alt="character"
           className="rounded mb-2 h-28 w-full object-cover"
-          onError={e => (e.currentTarget.src = './default-avatar.png')}
+          onError={e => (e.currentTarget.src = '/default-avatar.png')}
         />
         <h3 className="text-lg text-dndgold text-center mb-1">{character.name}</h3>
         <p className="text-xs text-center">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,7 +6,7 @@
 body {
   font-family: 'Cinzel', serif;
   font-size: 18px;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('./map-bg.jpg');
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/map-bg.jpg');
   background-size: cover;
   background-position: center;
   background-attachment: fixed;

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -54,7 +54,7 @@ function AdminLoginPage() {
   return (
     <div
       className="min-h-screen bg-cover bg-center flex items-center justify-center"
-      style={{ backgroundImage: `url('./map-bg.jpg')` }}
+      style={{ backgroundImage: `url('/map-bg.jpg')` }}
     >
       <div className="bg-[#2d1d14]/90 p-8 rounded-lg shadow-lg w-full max-w-md text-center text-white">
         <h1 className="text-3xl font-dnd mb-4">Admin Login</h1>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -84,7 +84,7 @@ export default function AdminPage() {
   return (
     <div
       className="min-h-screen bg-cover bg-center p-8 font-dnd text-white"
-      style={{ backgroundImage: "url('./map-bg.jpg')" }}
+      style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
       <h1 className="text-3xl text-dndgold mb-6">Панель Адміністратора</h1>
 

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -39,7 +39,7 @@ export default function CharacterCreatePage() {
   return (
     <div
       className="relative flex justify-center items-center min-h-screen font-dnd text-white bg-cover bg-center"
-      style={{ backgroundImage: "url('./map-bg.jpg')" }}
+      style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
       <div className="absolute top-4 right-4 flex gap-2 flex-wrap">
         <button

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -16,7 +16,7 @@ export default function CharacterListPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-cover bg-center p-8 font-dnd text-white" style={{ backgroundImage: "url('./map-bg.jpg')" }}>
+    <div className="min-h-screen bg-cover bg-center p-8 font-dnd text-white" style={{ backgroundImage: "url('/map-bg.jpg')" }}>
       <h1 className="text-3xl text-dndgold mb-6">Твої персонажі</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {characters.map(c => {

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -117,7 +117,7 @@ export default function LobbyPage() {
         {character && (
           <div className="flex items-center gap-3 mb-4 text-dndgold">
             <img
-              src={withApiHost(character.image) || './default-avatar.png'}
+              src={withApiHost(character.image) || '/default-avatar.png'}
               alt={character.name}
               className="w-12 h-12 object-cover rounded-full"
             />

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -26,7 +26,7 @@ function LoginPage() {
   return (
     <div
       className="min-h-screen bg-cover bg-center flex items-center justify-center"
-      style={{ backgroundImage: `url('./map-bg.jpg')` }}
+      style={{ backgroundImage: `url('/map-bg.jpg')` }}
     >
       <div className="bg-[#2d1d14]/90 p-8 rounded-lg shadow-lg w-full max-w-md text-center text-white">
         <h2 className="text-3xl font-dnd mb-4">{t('login')}</h2>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -58,7 +58,7 @@ const ProfilePage = () => {
   return (
     <div
       className="relative min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center p-6 font-dnd text-dndgold text-shadow"
-      style={{ backgroundImage: "url('./map-bg.jpg')" }}
+      style={{ backgroundImage: "url('/map-bg.jpg')" }}
     >
       <div className="absolute top-4 right-4 flex gap-2 flex-wrap">
         <button

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -41,7 +41,7 @@ function RegisterPage() {
 
     <div
       className="min-h-screen bg-cover bg-center flex items-center justify-center"
-      style={{ backgroundImage: `url('./map-bg.jpg')` }}
+      style={{ backgroundImage: `url('/map-bg.jpg')` }}
     >
       <div className="bg-[#2d1d14]/90 p-8 rounded-lg shadow-lg w-full max-w-md text-center text-white">
         <h2 className="text-3xl font-dnd mb-4">Реєстрація</h2>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   build: {
     chunkSizeWarningLimit: 1024,


### PR DESCRIPTION
## Summary
- configure Vite to build with `/` base
- revert default asset references to absolute paths

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68584582d9348322aa44a03ac10c9331