### PR TITLE
Fix asset paths for static frontend

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/',
+  base: './',
   plugins: [react()],
   build: {
     chunkSizeWarningLimit: 1024,


### PR DESCRIPTION
## Summary
- fix React bundle error by using relative base path in `vite.config.js`

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685848b582fc832284d8875014300f9f