### PR TITLE
Disable manual chunks

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,17 +8,18 @@ export default defineConfig({
     chunkSizeWarningLimit: 1024,
     rollupOptions: {
       output: {
-        manualChunks(id) {
-          if (id.includes('node_modules')) {
-            if (id.includes('i18next') || id.includes('react-i18next')) {
-              return 'i18n';
-            }
-            if (id.includes('react') || id.includes('react-dom')) {
-              return 'react';
-            }
-            return 'vendor';
-          }
-        },
+        // Use Vite's default chunking strategy
+        // manualChunks(id) {
+        //   if (id.includes('node_modules')) {
+        //     if (id.includes('i18next') || id.includes('react-i18next')) {
+        //       return 'i18n';
+        //     }
+        //     if (id.includes('react') || id.includes('react-dom')) {
+        //       return 'react';
+        //     }
+        //     return 'vendor';
+        //   }
+        // },
       },
     },
   },


### PR DESCRIPTION
## Summary
- use Vite's default chunking by commenting out `manualChunks`
- rebuild frontend bundle

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68585353baf48322922363f7e2ede0cd