### PR TITLE
Fix inventory item translation keys

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -119,7 +119,7 @@ export default function CharacterCard({
                     : '';
                 return (
                   <li key={idx}>
-                    {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                    {translateOrRaw(t, `inventory.${it.item}`, it.item)}
                     {it.amount > 1 ? ` x${it.amount}` : ''}
                     {bonusData}
                     {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
@@ -142,7 +142,7 @@ export default function CharacterCard({
                     : '';
                 return (
                   <li key={key}>
-                    {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                    {translateOrRaw(t, `inventory.${it.item}`, it.item)}
                     {it.amount > 1 ? ` x${it.amount}` : ''}
                     {bonusData}
                     {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -24,7 +24,7 @@ export default function InventoryList({ items, filter = 'all' }) {
         {filtered.map((item, i) => (
           <li key={i} className="text-dndgold">
 
-            {translateOrRaw(t, `inventory.${(item.item || item.name || item).toLowerCase()}`, item.item || item.name || item)}
+            {translateOrRaw(t, `inventory.${item.item || item.name || item}`, item.item || item.name || item)}
 
             {item.amount ? `x${item.amount}` : ''}
             {item.effect ? ` (${translateEffect(item.effect, t)})` : ''}

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -98,7 +98,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={idx}>
 
-                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateOrRaw(t, `inventory.${it.item}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}
@@ -129,7 +129,7 @@ export default function PlayerCard({ character, onSelect }) {
                   return (
                     <li key={key}>
 
-                      {translateOrRaw(t, `inventory.${it.item.toLowerCase()}`, it.item)}
+                      {translateOrRaw(t, `inventory.${it.item}`, it.item)}
 
                       {it.amount > 1 ? ` x${it.amount}` : ''}
                       {bonusData}


### PR DESCRIPTION
## Summary
- preserve original case when looking up inventory item translations

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6858591cd98c8322abb0219a04bc9c59