### PR TITLE
Add localized stat abbreviations

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -44,7 +44,14 @@
     "strength": "Strength",
     "intellect": "Intellect",
     "agility": "Agility",
-    "charisma": "Charisma"
+    "charisma": "Charisma",
+    "str": "STR",
+    "dex": "DEX",
+    "int": "INT",
+    "con": "CON",
+    "cha": "CHA",
+    "hp": "HP",
+    "mp": "MP"
   },
   "inventory": {
     "title": "Inventory:",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -44,7 +44,14 @@
     "strength": "Сила",
     "intellect": "Інтелект",
     "agility": "Спритність",
-    "charisma": "Харизма"
+    "charisma": "Харизма",
+    "str": "СИЛ",
+    "dex": "СПР",
+    "int": "ІНТ",
+    "con": "ВИТ",
+    "cha": "ХАР",
+    "hp": "HP",
+    "mp": "MP"
   },
   "inventory": {
     "title": "Інвентар:",


### PR DESCRIPTION
## Summary
- add abbreviations like STR/DEX etc. to `stats` in English and Ukrainian locale files
- abbreviations now translate properly when bonuses or effects are shown

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858591d3370832281bd80f230d43b4c