### PR TITLE
Add halfling translation and remove duplicate keys

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,7 +6,6 @@
   "admin": "Admin",
   "fields_required": "Please fill in all fields",
   "connecting": "Connecting...",
-  "unknown": "Unknown",
   "create_table": "Create table",
   "map_from_file": "Map from file",
   "mp": "MP",
@@ -67,6 +66,7 @@
     "orc": "Orc",
     "gnome": "Gnome",
     "dwarf": "Dwarf",
+    "halfling": "Halfling",
     "lizardman": "Lizardman"
   },
   "classes": {

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -6,7 +6,6 @@
   "admin": "Адмінка",
   "fields_required": "Заповніть усі поля",
   "connecting": "Підключення...",
-  "unknown": "Невідомо",
   "create_table": "Створити стіл",
   "map_from_file": "Карта з файлу",
   "mp": "MP",
@@ -67,6 +66,7 @@
     "orc": "Орк",
     "gnome": "Гном",
     "dwarf": "Дварф",
+    "halfling": "Гобіт",
     "lizardman": "Ящірка"
   },
   "classes": {


### PR DESCRIPTION
## Summary
- translate Halfling race in `en.json` and `ua.json`
- remove duplicate `unknown` entries from locale files
- ensure no duplicate keys remain

## Testing
- `npm test --silent -- --runInBand` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68586072e8d483228ed4bb1e2e2b795a