### PR TITLE
Fix race/class translation key priority

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -19,11 +19,11 @@ export default function CharacterCard({
   const raceKey =
     typeof character.race === 'string'
       ? character.race
-      : character.race?.name || character.race?.code || '';
+      : character.race?.code || character.race?.name || '';
   const classKey =
     typeof character.profession === 'string'
       ? character.profession
-      : character.profession?.name || character.profession?.code || '';
+      : character.profession?.code || character.profession?.name || '';
   const raceKeyLower = (raceKey || '').toLowerCase();
   const classKeyLower = (classKey || '').toLowerCase();
 


### PR DESCRIPTION
## Summary
- in character cards, use `code` before `name` when determining race and class keys

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858663c749c83229701428700bd2657