### PR TITLE
fix: remove duplicate kickPlayer function

### DIFF
--- a/frontend/src/components/PlayerStatusTable.jsx
+++ b/frontend/src/components/PlayerStatusTable.jsx
@@ -9,7 +9,6 @@ export default function PlayerStatusTable({ players, isGM, onEdit, onKick }) {
   const { hp, mp, updateHp, updateMp } = useGameState();
   const { t } = useTranslation();
   const [dmg, setDmg] = useState({});
-  const { t } = useTranslation();
 
   const applyDamage = (uid) => {
     const val = Number(dmg[uid]);

--- a/frontend/src/pages/gm/GMControlPage.jsx
+++ b/frontend/src/pages/gm/GMControlPage.jsx
@@ -116,10 +116,6 @@ function Control() {
     }
   };
 
-  const kickPlayer = (uid) => {
-    socket.emit('kick-player', { tableId: id, userId: uid });
-  };
-
 
   const sendMessage = () => {
     if (!message.trim()) return;


### PR DESCRIPTION
## Summary
- remove duplicate kickPlayer handler
- drop extra `useTranslation` call in PlayerStatusTable
- run `npm run build` to ensure the frontend compiles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68586d0d3b508322afcb9348dcee79a0