### PR TITLE
Fix duplicate import in GMControlPage

### DIFF
--- a/frontend/src/pages/gm/GMControlPage.jsx
+++ b/frontend/src/pages/gm/GMControlPage.jsx
@@ -11,7 +11,6 @@ import InventoryEditor from '../../components/InventoryEditor';
 import { withApiHost } from '../../utils/imageUtils';
 import socket from '../../api/socket';
 import api from '../../api/axios';
-import { withApiHost } from '../../utils/imageUtils';
 
 
 function Control({ tableId }) {


### PR DESCRIPTION
## Summary
- remove duplicate `withApiHost` import
- rebuild frontend to ensure no compile errors

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685875a985ec83229d8db6b157595957