### PR TITLE
Fix undefined raceKey/classKey in CharacterCard

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -28,6 +28,9 @@ export default function CharacterCard({
   const classKeyLower = (classCode || '').toLowerCase();
   const raceName = character.race?.name || raceCode;
   const className = character.profession?.name || classCode;
+  const raceKey = character?.race?.code || character?.race?.name || 'unknown';
+  const classKey = character?.profession?.code || character?.profession?.name ||
+    'unknown';
 
   return (
     <>


### PR DESCRIPTION
## Summary
- prevent `raceKey is not defined` runtime error by defining raceKey and classKey in CharacterCard

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685877b71820832286be4f217240e8ed