### PR TITLE
Fix import path in CharacterCreatePage

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createCharacter } from '../../utils/api';
+import { createCharacter } from '../utils/api';
 
 const CharacterCreatePage = () => {
   const [name, setName] = useState('');


### PR DESCRIPTION
## Summary
- fix incorrect utils import path in `CharacterCreatePage.jsx`
- verify Vite build passes

## Testing
- `npm run build` inside `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685886393d7c8322908866a28f07169f