### PR TITLE
Use mongoose schemas for Race and Profession

### DIFF
--- a/backend/src/models/Profession.js
+++ b/backend/src/models/Profession.js
@@ -1,38 +1,11 @@
-export default [
-  {
-    code: "warrior",
-    name: "Воїн",
-    modifiers: { str: 2, con: 1 },
-    inventory: ["Меч (+2 СИЛ)", "Латна броня (+2 ВИТ)"]
-  },
-  {
-    code: "bard",
-    name: "Бард",
-    modifiers: { cha: 2, dex: 1 },
-    inventory: ["Лютня (+2 ХАР)", "Пісенник"]
-  },
-  {
-    code: "mage",
-    name: "Маг",
-    modifiers: { int: 2, wis: 1 },
-    inventory: ["Жезл", "Магічна книга"]
-  },
-  {
-    code: "cleric",
-    name: "Клірик",
-    modifiers: { wis: 2, con: 1 },
-    inventory: ["Святий амулет", "Книга молитов"]
-  },
-  {
-    code: "assassin",
-    name: "Асасін",
-    modifiers: { dex: 2, str: 1 },
-    inventory: ["Кинджал", "Плащ тіні"]
-  },
-  {
-    code: "rogue",
-    name: "Злодій",
-    modifiers: { dex: 2, int: 1 },
-    inventory: ["Відмичка", "Короткий меч"]
-  }
-];
+const mongoose = require('mongoose');
+
+const professionSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  code: { type: String, required: true, unique: true },
+  description: { type: String, default: '' },
+  modifiers: { type: Map, of: Number, default: {} },
+  inventory: [{ type: String }]
+}, { timestamps: true });
+
+module.exports = mongoose.model('Profession', professionSchema);

--- a/backend/src/models/Race.js
+++ b/backend/src/models/Race.js
@@ -1,32 +1,10 @@
-export default [
-  {
-    code: "human",
-    name: "Людина",
-    modifiers: { str: 1, int: 1, con: 1 }
-  },
-  {
-    code: "wood_elf",
-    name: "Лісовий ельф",
-    modifiers: { dex: 2, wis: 1 }
-  },
-  {
-    code: "dark_elf",
-    name: "Темний ельф",
-    modifiers: { dex: 2, cha: 1 }
-  },
-  {
-    code: "orc",
-    name: "Орк",
-    modifiers: { str: 2, con: 1 }
-  },
-  {
-    code: "halfling",
-    name: "Напіврослик",
-    modifiers: { dex: 2, cha: 1 }
-  },
-  {
-    code: "lizardman",
-    name: "Ящеролюд",
-    modifiers: { con: 2, wis: 1 }
-  }
-];
+const mongoose = require('mongoose');
+
+const raceSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  code: { type: String, required: true, unique: true },
+  description: { type: String, default: '' },
+  modifiers: { type: Map, of: Number, default: {} }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Race', raceSchema);


### PR DESCRIPTION
## Summary
- implement `Race` and `Profession` as real mongoose models
- update models to expose schemas with name and code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858863bd6208322bdc9e53f5a3c5864