### PR TITLE
Add 404 middleware

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -56,6 +56,11 @@ app.use('/api/ai', require('./routes/ai'));
 // Simple ping route used to wake the server
 app.use('/api/ping', require('./routes/ping'));
 
+// 404 handler
+app.use((req, res) => {
+  res.status(404).json({ message: 'Not found' });
+});
+
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;
 


### PR DESCRIPTION
## Summary
- return a standard 404 response for unknown routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858863d4218832295266343b3071522