### PR TITLE
Add ESLint to frontend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for helping improve this project! Please follow these guidelines when 
 ## Development setup
 - Run `./setup.sh` to install backend and frontend dependencies.
 - See `MANUAL_QA.md` for manual testing steps.
+- Run `npm run lint` inside `frontend` before committing to check code style.
 
 ## Binary assets
 Avatar images and other static artwork are stored directly in this repository. The current avatar assets occupy about **40 KB** in total.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,12 @@ npm run lint
 npm run format
 ```
 
-The frontend does not currently include separate lint or format commands.
+You can lint the frontend code with:
+
+```bash
+cd frontend
+npm run lint
+```
 
 ## Character Basics
 

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "npx serve -s dist",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "lint": "eslint ."
   },
   "dependencies": {
     "axios": "^1.6.0",
@@ -37,6 +38,8 @@
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.14",
     "cross-env": "^7.0.3",
+    "eslint": "^9.0.0",
+    "eslint-plugin-react": "^7.34.1",
     "jest": "^29.7.0",
     "postcss": "^8.4.24",
     "socket.io": "^4.8.1",


### PR DESCRIPTION
## Summary
- add eslint and eslint-plugin-react dev dependencies
- configure ESLint for the React frontend
- expose `npm run lint` in frontend package.json
- document lint command in CONTRIBUTING and README

## Testing
- `npm test` within `backend` *(fails: jest not found)*
- `npm test` within `frontend` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858863f39dc8322867448c476704da8