### PR TITLE
Fix path to api in CharacterCreatePage

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createCharacter } from '../../utils/api';
+import { createCharacter } from '../utils/api';
 
 const CharacterCreatePage = () => {
   const [name, setName] = useState('');


### PR DESCRIPTION
## Summary
- fix the API import path in `CharacterCreatePage.jsx`
- verify frontend build

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858879cefe883228b3ef6bdb7dbd6f5