### PR TITLE
Update races and professions lists

### DIFF
--- a/backend/src/models/Profession.js
+++ b/backend/src/models/Profession.js
@@ -1,38 +1,32 @@
 export default [
   {
-    code: "warrior",
-    name: "Воїн",
-    modifiers: { str: 2, con: 1 },
-    inventory: ["Меч (+2 СИЛ)", "Латна броня (+2 ВИТ)"]
+    code: 'warrior',
+    name: 'Воїн',
+    modifiers: { strength: 2, defense: 1 }
   },
   {
-    code: "bard",
-    name: "Бард",
-    modifiers: { cha: 2, dex: 1 },
-    inventory: ["Лютня (+2 ХАР)", "Пісенник"]
+    code: 'mage',
+    name: 'Маг',
+    modifiers: { intellect: 2, charisma: 1 }
   },
   {
-    code: "mage",
-    name: "Маг",
-    modifiers: { int: 2, wis: 1 },
-    inventory: ["Жезл", "Магічна книга"]
+    code: 'archer',
+    name: 'Лучник',
+    modifiers: { agility: 1, strength: 1 }
   },
   {
-    code: "cleric",
-    name: "Клірик",
-    modifiers: { wis: 2, con: 1 },
-    inventory: ["Святий амулет", "Книга молитов"]
+    code: 'paladin',
+    name: 'Паладин',
+    modifiers: { strength: 2, charisma: 2 }
   },
   {
-    code: "assassin",
-    name: "Асасін",
-    modifiers: { dex: 2, str: 1 },
-    inventory: ["Кинджал", "Плащ тіні"]
+    code: 'bard',
+    name: 'Бард',
+    modifiers: { charisma: 2, agility: 1 }
   },
   {
-    code: "rogue",
-    name: "Злодій",
-    modifiers: { dex: 2, int: 1 },
-    inventory: ["Відмичка", "Короткий меч"]
+    code: 'healer',
+    name: 'Цілитель',
+    modifiers: { charisma: 2, health: 1 }
   }
 ];

--- a/backend/src/models/Race.js
+++ b/backend/src/models/Race.js
@@ -1,32 +1,52 @@
 export default [
   {
-    code: "human",
-    name: "Людина",
-    modifiers: { str: 1, int: 1, con: 1 }
+    code: 'human_male',
+    name: 'Людина (чоловік)',
+    modifiers: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 }
   },
   {
-    code: "wood_elf",
-    name: "Лісовий ельф",
-    modifiers: { dex: 2, wis: 1 }
+    code: 'human_female',
+    name: 'Людина (жінка)',
+    modifiers: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 }
   },
   {
-    code: "dark_elf",
-    name: "Темний ельф",
-    modifiers: { dex: 2, cha: 1 }
+    code: 'elf_male',
+    name: 'Ельф (чоловік)',
+    modifiers: { agility: 2, intellect: 1 }
   },
   {
-    code: "orc",
-    name: "Орк",
-    modifiers: { str: 2, con: 1 }
+    code: 'elf_female',
+    name: 'Ельф (жінка)',
+    modifiers: { agility: 2, intellect: 1 }
   },
   {
-    code: "halfling",
-    name: "Напіврослик",
-    modifiers: { dex: 2, cha: 1 }
+    code: 'orc_male',
+    name: 'Орк (чоловік)',
+    modifiers: { strength: 2, health: 1 }
   },
   {
-    code: "lizardman",
-    name: "Ящеролюд",
-    modifiers: { con: 2, wis: 1 }
+    code: 'orc_female',
+    name: 'Орк (жінка)',
+    modifiers: { strength: 2, health: 1 }
+  },
+  {
+    code: 'gnome_male',
+    name: 'Гном (чоловік)',
+    modifiers: { health: 2, intellect: 1 }
+  },
+  {
+    code: 'gnome_female',
+    name: 'Гном (жінка)',
+    modifiers: { health: 2, intellect: 1 }
+  },
+  {
+    code: 'dwarf_male',
+    name: 'Дварф (чоловік)',
+    modifiers: { strength: 2, charisma: 1 }
+  },
+  {
+    code: 'dwarf_female',
+    name: 'Дварф (жінка)',
+    modifiers: { strength: 2, charisma: 1 }
   }
 ];

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -6,7 +6,7 @@ import { createCharacter } from '../../utils/api';
 const CharacterCreatePage = () => {
   const [name, setName] = useState('');
   const [gender, setGender] = useState('male');
-  const [race, setRace] = useState('wood_elf');
+  const [race, setRace] = useState('human_male');
   const [profession, setProfession] = useState('warrior');
   const [description, setDescription] = useState('');
   const navigate = useNavigate();
@@ -34,18 +34,24 @@ const CharacterCreatePage = () => {
           <option value="female">Жінка</option>
         </select>
         <select value={race} onChange={(e) => setRace(e.target.value)}>
-          <option value="wood_elf">Лісовий ельф</option>
-          <option value="dark_elf">Темний ельф</option>
-          <option value="human">Людина</option>
-          <option value="halfling">Піврослик</option>
-          <option value="lizardman">Ящеролюдина</option>
+          <option value="human_male">Людина (чоловік)</option>
+          <option value="human_female">Людина (жінка)</option>
+          <option value="elf_male">Ельф (чоловік)</option>
+          <option value="elf_female">Ельф (жінка)</option>
+          <option value="orc_male">Орк (чоловік)</option>
+          <option value="orc_female">Орк (жінка)</option>
+          <option value="gnome_male">Гном (чоловік)</option>
+          <option value="gnome_female">Гном (жінка)</option>
+          <option value="dwarf_male">Дварф (чоловік)</option>
+          <option value="dwarf_female">Дварф (жінка)</option>
         </select>
         <select value={profession} onChange={(e) => setProfession(e.target.value)}>
           <option value="warrior">Воїн</option>
+          <option value="mage">Маг</option>
+          <option value="archer">Лучник</option>
           <option value="paladin">Паладин</option>
-          <option value="wizard">Маг</option>
           <option value="bard">Бард</option>
-          <option value="assassin">Асасін</option>
+          <option value="healer">Цілитель</option>
         </select>
         <textarea
           placeholder="Опис"

--- a/frontend/src/pages/CreateCharacterPage.jsx
+++ b/frontend/src/pages/CreateCharacterPage.jsx
@@ -8,7 +8,7 @@ import { useToast } from '../context/ToastContext';
 const CreateCharacterPage = () => {
   const [name, setName] = useState('');
   const [gender, setGender] = useState('male');
-  const [race, setRace] = useState('wood_elf');
+  const [race, setRace] = useState('human_male');
   const [profession, setProfession] = useState('warrior');
   const [description, setDescription] = useState('');
   const [error, setError] = useState('');
@@ -42,18 +42,24 @@ const CreateCharacterPage = () => {
           <option value="female">Жінка</option>
         </select>
         <select value={race} onChange={(e) => setRace(e.target.value)}>
-          <option value="wood_elf">Лісовий ельф</option>
-          <option value="dark_elf">Темний ельф</option>
-          <option value="human">Людина</option>
-          <option value="halfling">Піврослик</option>
-          <option value="lizardman">Ящеролюдина</option>
+          <option value="human_male">Людина (чоловік)</option>
+          <option value="human_female">Людина (жінка)</option>
+          <option value="elf_male">Ельф (чоловік)</option>
+          <option value="elf_female">Ельф (жінка)</option>
+          <option value="orc_male">Орк (чоловік)</option>
+          <option value="orc_female">Орк (жінка)</option>
+          <option value="gnome_male">Гном (чоловік)</option>
+          <option value="gnome_female">Гном (жінка)</option>
+          <option value="dwarf_male">Дварф (чоловік)</option>
+          <option value="dwarf_female">Дварф (жінка)</option>
         </select>
         <select value={profession} onChange={(e) => setProfession(e.target.value)}>
           <option value="warrior">Воїн</option>
+          <option value="mage">Маг</option>
+          <option value="archer">Лучник</option>
           <option value="paladin">Паладин</option>
-          <option value="wizard">Маг</option>
           <option value="bard">Бард</option>
-          <option value="assassin">Асасін</option>
+          <option value="healer">Цілитель</option>
         </select>
         <textarea
           placeholder="Опис персонажа"

--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -6,7 +6,6 @@ export function getClassBorderColor(profession) {
     paladin: 'border-yellow-600',
     bard: 'border-purple-600',
     healer: 'border-teal-600',
-    druid: 'border-green-700',
   };
   const key = (profession || '').toLowerCase();
   if (!key) return 'border-dndgold';


### PR DESCRIPTION
## Summary
- replace old race definitions with gendered variants
- update available professions with new stat bonuses
- show updated options on character creation pages
- drop obsolete class reference in color utility

## Testing
- `npm test` *(backend)* *(fails: Jest couldn't parse ES module syntax)*
- `npm test` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_685887a14d348322af9fe5fd6998da88