### PR TITLE
Add gender field to Character model

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -110,6 +110,7 @@ exports.create = async (req, res) => {
   const newChar = new Character({
       user: req.user.id,
       name,
+      gender,
       description,
       image: avatar,
       race: race[0]?._id,

--- a/backend/src/models/Character.js
+++ b/backend/src/models/Character.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const characterSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   name: { type: String, required: true },
+  gender: { type: String, enum: ['male', 'female'], required: true },
   race: { type: mongoose.Schema.Types.ObjectId, ref: 'Race' },
   profession: { type: mongoose.Schema.Types.ObjectId, ref: 'Profession' },
   stats: {

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -50,6 +50,7 @@ describe('Character Controller - create', () => {
 
     expect(saved.stats.intellect).toBe(8); // Mage intellect bonus applied
     expect(saved.stats.agility).toBe(7); // Elf agility bonus applied
+    expect(saved.gender).toBe('male');
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalled();
   });
@@ -82,6 +83,7 @@ describe('Character Controller - create', () => {
       agility: 5,
       charisma: 5
     });
+    expect(saved.gender).toBe('male');
   });
 
   it('passes codes to generateInventory and saves its result', async () => {
@@ -104,6 +106,7 @@ describe('Character Controller - create', () => {
 
     expect(generateInventory).toHaveBeenCalledWith('elf', 'mage');
     expect(saved.inventory).toEqual(inv);
+    expect(saved.gender).toBe('male');
   });
 
   it('returns 400 if races or professions are missing', async () => {
@@ -147,6 +150,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(saved.image).toBe('/uploads/avatars/avatar.png');
+    expect(saved.gender).toBe('male');
     expect(res.status).toHaveBeenCalledWith(201);
   });
 
@@ -203,6 +207,7 @@ describe('Character Controller - create', () => {
     expect(Profession.aggregate).not.toHaveBeenCalled();
     expect(saved.race).toBe('r2');
     expect(saved.profession).toBe('p2');
+    expect(saved.gender).toBe('male');
     expect(res.status).toHaveBeenCalledWith(201);
   });
 });


### PR DESCRIPTION
## Summary
- include `gender` in Character schema
- persist gender when creating a character
- update unit tests for gender

## Testing
- `node --experimental-vm-modules ./node_modules/.bin/jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685887a406b88322b4df46a4abb07981