### PR TITLE
Update races and professions

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -49,26 +49,20 @@ async function seed() {
   // ];
   // const characteristics = ['HP', 'MP', 'Strength', 'Agility', 'Intellect'];
 
-  // Gendered races
   const races = [
-    { code: 'human_male', name: 'Людина (чоловік)' },
-    { code: 'human_female', name: 'Людина (жінка)' },
-    { code: 'elf_male', name: 'Ельф (чоловік)' },
-    { code: 'elf_female', name: 'Ельф (жінка)' },
-    { code: 'orc_male', name: 'Орк (чоловік)' },
-    { code: 'orc_female', name: 'Орк (жінка)' },
-    { code: 'gnome_male', name: 'Гном (чоловік)' },
-    { code: 'gnome_female', name: 'Гном (жінка)' },
-    { code: 'dwarf_male', name: 'Дварф (чоловік)' },
-    { code: 'dwarf_female', name: 'Дварф (жінка)' },
+    { code: 'human', name: 'Людина' },
+    { code: 'forest_elf', name: 'Лісовий ельф' },
+    { code: 'dark_elf', name: 'Темний ельф' },
+    { code: 'gnome', name: 'Гном' },
+    { code: 'dwarf', name: 'Дварф' },
+    { code: 'orc', name: 'Орк' },
   ];
   const professions = [
     { code: 'warrior', name: 'Воїн' },
-    { code: 'mage', name: 'Маг' },
-    { code: 'archer', name: 'Лучник' },
+    { code: 'wizard', name: 'Маг' },
+    { code: 'assassin', name: 'Асасін' },
     { code: 'paladin', name: 'Паладин' },
-    { code: 'bard', name: 'Бард' },
-    { code: 'healer', name: 'Цілитель' }
+    { code: 'bard', name: 'Бард' }
   ];
   const characteristics = [
     'health',
@@ -93,7 +87,7 @@ async function seed() {
         { item: 'Зілля здоров’я' }
       ]
     },
-    mage: {
+    wizard: {
       weapon: [
         { item: 'Магічний посох', bonus: { intellect: 2 } },
         { item: 'Чарівна паличка', bonus: { intellect: 1 } }
@@ -107,20 +101,7 @@ async function seed() {
         { item: 'Книга заклять' }
       ]
     },
-    healer: {
-      weapon: [
-        { item: 'Жезл лікування', bonus: { charisma: 1 } },
-        { item: 'Священний посох', bonus: { charisma: 1 } }
-      ],
-      armor: [
-        { item: 'Легка ряса', bonus: { health: 1 } },
-        { item: 'Травник' }
-      ],
-      misc: [
-        { item: 'Зілля лікування' }
-      ]
-    },
-    archer: {
+    assassin: {
       weapon: [
         { item: 'Лук', bonus: { agility: 1 } },
         { item: 'Арбалет', bonus: { agility: 1 } }
@@ -161,7 +142,8 @@ async function seed() {
 
   const raceInventory = {
     human: [{ item: 'Монета удачі', bonus: { charisma: 1 } }],
-    elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
+    forest_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
+    dark_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
     orc: [{ item: 'Кістяний талісман', bonus: { strength: 1 } }],
     gnome: [{ item: 'Гвинтовий ключ' }],
     dwarf: [{ item: 'Похідна кружка', bonus: { health: 1 } }]

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -37,7 +37,7 @@ exports.getAllByUser = async (req, res) => {
 exports.create = async (req, res) => {
   try {
 
-    let { name, description, image, gender, raceId, professionId } = req.body;
+    let { name, description, image, gender, raceId, professionId, race: raceCode, profession: professionCode } = req.body;
 
 
     if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 50) {
@@ -99,9 +99,8 @@ exports.create = async (req, res) => {
 
 
   const raceCodeRaw = (race[0].code || race[0].name).toLowerCase();
-  const detectedGender = raceCodeRaw.endsWith('_female') ? 'female' : 'male';
-  const finalGender = (gender && ['male', 'female'].includes(gender)) ? gender : detectedGender;
-  const raceBase = raceCodeRaw.replace(/_(male|female)$/, '');
+  const finalGender = (gender && ['male', 'female'].includes(gender)) ? gender : 'male';
+  const raceBase = raceCodeRaw.replace(/_(male|female)$/i, '');
   const classCodeLower = (profession[0].code || profession[0].name).toLowerCase();
 
   const stats = generateStats(raceBase, classCodeLower, finalGender);

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -4,7 +4,8 @@ const slug = require('./slugify');
 
 const raceInventory = {
   human: [{ item: 'Монета удачі', amount: 1, bonus: { charisma: 1 } }],
-  elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
+  forest_elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
+  dark_elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
   orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { strength: 1 } }],
   gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
   dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { health: 1 } }]
@@ -31,7 +32,7 @@ async function generateInventory(raceCode, classCode) {
     }
   }
 
-  const baseCode = raceCode.split('_')[0];
+  const baseCode = raceCode.replace(/_(male|female)$/i, '');
   const raceItems = raceInventory[baseCode] || [];
   for (const r of raceItems) {
     result.push({

--- a/backend/src/utils/generateStats.js
+++ b/backend/src/utils/generateStats.js
@@ -12,7 +12,11 @@ const raceModifiers = {
     male: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 },
     female: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 },
   },
-  elf: {
+  forest_elf: {
+    male: { agility: 2, intellect: 1 },
+    female: { agility: 2, intellect: 1 },
+  },
+  dark_elf: {
     male: { agility: 2, intellect: 1 },
     female: { agility: 2, intellect: 1 },
   },
@@ -32,9 +36,8 @@ const raceModifiers = {
 
 const classModifiers = {
   warrior: { strength: 2, defense: 1 },
-  mage: { intellect: 2, charisma: 1 },
-  healer: { charisma: 2, health: 1 },
-  archer: { agility: 1, strength: 1 },
+  wizard: { intellect: 2, charisma: 1 },
+  assassin: { agility: 1, strength: 1 },
   bard: { charisma: 2, agility: 1 },
   paladin: { strength: 2, charisma: 2 },
 };

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -16,7 +16,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   generateInventory.mockResolvedValue([]);
   jest.spyOn(console, 'warn').mockImplementation(() => {});
-  const q = Promise.resolve({ _id: 'c1', race: { name: 'Elf', code: 'elf' }, profession: { name: 'Mage', code: 'mage' } });
+  const q = Promise.resolve({ _id: 'c1', race: { name: 'Forest Elf', code: 'forest_elf' }, profession: { name: 'Wizard', code: 'wizard' } });
   q.populate = jest.fn().mockReturnValue(q);
   Character.findById = jest.fn(() => q);
 });
@@ -28,8 +28,8 @@ afterEach(() => {
 describe('Character Controller - create', () => {
   it('applies race bonuses and class minimums', async () => {
 
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Forest Elf', code: 'forest_elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard', code: 'wizard' }]);
 
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
@@ -48,15 +48,15 @@ describe('Character Controller - create', () => {
 
     Math.random.mockRestore();
 
-    expect(saved.stats.intellect).toBe(8); // Mage intellect bonus applied
+    expect(saved.stats.intellect).toBe(8); // Wizard intellect bonus applied
     expect(saved.stats.agility).toBe(7); // Elf agility bonus applied
     expect(saved.gender).toBe('male');
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalled();
   });
 
-  it('handles gendered race codes correctly', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Орк (чоловік)', code: 'orc_male' }]);
+  it('defaults gender to male when not provided', async () => {
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Орк', code: 'orc' }]);
     Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Warrior', code: 'warrior' }]);
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
@@ -87,8 +87,8 @@ describe('Character Controller - create', () => {
   });
 
   it('passes codes to generateInventory and saves its result', async () => {
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Forest Elf', code: 'forest_elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard', code: 'wizard' }]);
 
     const inv = [{ item: 'Test', amount: 1, bonus: {} }];
     generateInventory.mockResolvedValue(inv);
@@ -104,7 +104,7 @@ describe('Character Controller - create', () => {
 
     await characterController.create(req, res);
 
-    expect(generateInventory).toHaveBeenCalledWith('elf', 'mage');
+    expect(generateInventory).toHaveBeenCalledWith('forest_elf', 'wizard');
     expect(saved.inventory).toEqual(inv);
     expect(saved.gender).toBe('male');
   });
@@ -129,8 +129,8 @@ describe('Character Controller - create', () => {
 
   it('uses uploaded avatar when file provided', async () => {
 
-    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Elf', code: 'elf' }]);
-    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Mage', code: 'mage' }]);
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Forest Elf', code: 'forest_elf' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard', code: 'wizard' }]);
 
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
 
@@ -188,7 +188,7 @@ describe('Character Controller - create', () => {
 
   it('uses provided raceId and professionId', async () => {
     Race.findById.mockResolvedValue({ _id: 'r2', name: 'Orc', code: 'orc' });
-    Profession.findById.mockResolvedValue({ _id: 'p2', name: 'Archer', code: 'archer' });
+    Profession.findById.mockResolvedValue({ _id: 'p2', name: 'Assassin', code: 'assassin' });
 
     let saved;
     Character.mockImplementation(data => {
@@ -213,7 +213,7 @@ describe('Character Controller - create', () => {
 
   it('resolves race and profession codes to IDs', async () => {
     Race.findOne.mockResolvedValue({ _id: 'r3', name: 'Orc', code: 'orc' });
-    Profession.findOne.mockResolvedValue({ _id: 'p3', name: 'Mage', code: 'mage' });
+    Profession.findOne.mockResolvedValue({ _id: 'p3', name: 'Wizard', code: 'wizard' });
 
     let saved;
     Character.mockImplementation(data => {
@@ -221,13 +221,13 @@ describe('Character Controller - create', () => {
       return { save: jest.fn().mockResolvedValue(data) };
     });
 
-    const req = { user: { id: 'u1' }, body: { name: 'Hero', race: 'orc', profession: 'mage' } };
+    const req = { user: { id: 'u1' }, body: { name: 'Hero', race: 'orc', profession: 'wizard' } };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
     await characterController.create(req, res);
 
     expect(Race.findOne).toHaveBeenCalledWith({ code: 'orc' });
-    expect(Profession.findOne).toHaveBeenCalledWith({ code: 'mage' });
+    expect(Profession.findOne).toHaveBeenCalledWith({ code: 'wizard' });
     expect(Race.aggregate).not.toHaveBeenCalled();
     expect(Profession.aggregate).not.toHaveBeenCalled();
     expect(saved.race).toBe('r3');

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -15,7 +15,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
 
-    const items = await generateInventory('orc_male', 'warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     expect(items).toEqual([
@@ -30,7 +30,7 @@ describe('generateInventory', () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
-    const items = await generateInventory('orc_female', 'warrior');
+    const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
     expect(items).toEqual([

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -24,7 +24,7 @@ describe('seed script', () => {
   });
 
   it('creates starting sets for each class', async () => {
-    const codes = ['warrior','mage','archer','paladin','bard','healer'];
+    const codes = ['warrior','wizard','assassin','paladin','bard'];
     for (const code of codes) {
       const count = await StartingSet.countDocuments({ classCode: code });
       expect(count).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- revise seeding data to new races and professions
- drop gendered race logic in character creation and utilities
- update inventory and stat generators for new codes
- adjust unit tests for updated data

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68599e92d85c8322864e851aa35e8a26