### PR TITLE
Use DB modifiers for stats

### DIFF
--- a/backend/src/utils/generateStats.js
+++ b/backend/src/utils/generateStats.js
@@ -1,3 +1,6 @@
+const Race = require('../models/Race');
+const Profession = require('../models/Profession');
+
 const baseStats = {
   health: 5,
   defense: 5,
@@ -7,54 +10,35 @@ const baseStats = {
   charisma: 5,
 };
 
-const raceModifiers = {
-  human: {
-    male: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 },
-    female: { health: 1, defense: 1, strength: 1, intellect: 1, agility: 1, charisma: 1 },
-  },
-  elf: {
-    male: { agility: 2, intellect: 1 },
-    female: { agility: 2, intellect: 1 },
-  },
-  orc: {
-    male: { strength: 2, health: 1 },
-    female: { strength: 2, health: 1 },
-  },
-  gnome: {
-    male: { health: 2, intellect: 1 },
-    female: { health: 2, intellect: 1 },
-  },
-  dwarf: {
-    male: { strength: 2, charisma: 1 },
-    female: { strength: 2, charisma: 1 },
-  },
-};
+function toObj(map) {
+  if (!map) return {};
+  if (typeof map.entries === 'function') {
+    return Object.fromEntries(map.entries());
+  }
+  return map;
+}
 
-const classModifiers = {
-  warrior: { strength: 2, defense: 1 },
-  mage: { intellect: 2, charisma: 1 },
-  healer: { charisma: 2, health: 1 },
-  archer: { agility: 1, strength: 1 },
-  bard: { charisma: 2, agility: 1 },
-  paladin: { strength: 2, charisma: 2 },
-};
-
-function generateStats(race, charClass, gender = 'male') {
+async function generateStats(raceCode, professionCode) {
   const stats = { ...baseStats };
 
-  const raceMods = (raceModifiers[race] && raceModifiers[race][gender]) || {};
+  const race = await Race.findOne({ code: raceCode });
+  const profession = await Profession.findOne({ code: professionCode });
+
+  const raceMods = toObj(race && race.modifiers);
   for (const key in raceMods) {
+    if (stats[key] === undefined) stats[key] = 0;
     stats[key] += raceMods[key];
   }
 
-  const classMods = classModifiers[charClass] || {};
-  for (const key in classMods) {
-    stats[key] += classMods[key];
+  const profMods = toObj(profession && profession.modifiers);
+  for (const key in profMods) {
+    if (stats[key] === undefined) stats[key] = 0;
+    stats[key] += profMods[key];
   }
 
   for (const key of Object.keys(stats)) {
     const hasRace = raceMods[key] !== undefined;
-    const hasClass = classMods[key] !== undefined;
+    const hasClass = profMods[key] !== undefined;
     if (!hasRace && !hasClass) {
       stats[key] = Math.max(stats[key], Math.floor(Math.random() * 8) + 3);
     }

--- a/backend/tests/generateStats.test.js
+++ b/backend/tests/generateStats.test.js
@@ -1,9 +1,18 @@
+const Race = require('../src/models/Race');
+const Profession = require('../src/models/Profession');
+
+jest.mock('../src/models/Race');
+jest.mock('../src/models/Profession');
+
 const generateStats = require('../src/utils/generateStats');
 
 describe('generateStats', () => {
-  it('applies race and class bonuses', () => {
+  it('applies race and class bonuses', async () => {
+    Race.findOne.mockResolvedValue({ modifiers: new Map([['strength', 2], ['health', 1]]) });
+    Profession.findOne.mockResolvedValue({ modifiers: new Map([['strength', 2], ['defense', 1]]) });
+
     jest.spyOn(Math, 'random').mockReturnValue(0);
-    const stats = generateStats('orc', 'warrior', 'male');
+    const stats = await generateStats('orc_male', 'warrior');
     Math.random.mockRestore();
     expect(stats).toEqual({
       health: 6,


### PR DESCRIPTION
## Summary
- fetch race and profession modifiers from Mongo
- apply these modifiers in generateStats
- mock database access in generateStats tests

## Testing
- `npm test -- -i` *(fails: Character Controller tests do not pass)*

------
https://chatgpt.com/codex/tasks/task_e_68599e9d3c6c8322aae61323183ac624