### PR TITLE
Fix character code lookup and tests

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -37,7 +37,16 @@ exports.getAllByUser = async (req, res) => {
 exports.create = async (req, res) => {
   try {
 
-    let { name, description, image, gender, raceId, professionId } = req.body;
+    let {
+      name,
+      description,
+      image,
+      gender,
+      raceId,
+      professionId,
+      raceCode,
+      professionCode
+    } = req.body;
 
 
     if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 50) {
@@ -119,7 +128,6 @@ exports.create = async (req, res) => {
   const newChar = new Character({
       user: req.user.id,
       name,
-      gender,
       description,
       image: avatar,
       gender: finalGender,

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -221,7 +221,10 @@ describe('Character Controller - create', () => {
       return { save: jest.fn().mockResolvedValue(data) };
     });
 
-    const req = { user: { id: 'u1' }, body: { name: 'Hero', race: 'orc', profession: 'mage' } };
+    const req = {
+      user: { id: 'u1' },
+      body: { name: 'Hero', raceCode: 'orc', professionCode: 'mage' }
+    };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
     await characterController.create(req, res);


### PR DESCRIPTION
## Summary
- allow create route to accept `raceCode` and `professionCode`
- remove redundant gender field when saving characters
- test creating characters using IDs or codes

## Testing
- `./setup.sh`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68599e9de91c83229f41b26fe675f428