### PR TITLE
Scope starting sets by race

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,24 @@ const stats = generateStats('Ельф (жінка)', 'Маг');
 
 ### Starter Inventory
 
-Each class provides a starter kit of equipment. Race specific trinkets are then
-added to the pack. The `generateInventory` helper merges both lists when a
-character is created.
+Starting equipment now depends on **both** race and class. The seed script
+creates three starter sets for every combination using an `inventorySets`
+object. `generateInventory` picks a random set for the provided codes and then
+adds race specific items.
 
 ```js
+const inventorySets = {
+  orc_male: {
+    warrior: [
+      ['Меч', 'Щит', 'Зілля здоров’я'],
+      ['Меч', 'Шкіряна броня', 'Зілля здоров’я'],
+      ['Сокира', 'Щит', 'Зілля здоров’я']
+    ]
+  }
+};
+
 const inventory = generateInventory('Орк (чоловік)', 'Воїн');
-// => ['Меч', 'Щит', 'Шкіряна броня', 'Зілля здоров’я', 'Кістяний талісман']
+// => ['Меч', 'Шкіряна броня', 'Зілля здоров’я', 'Кістяний талісман']
 ```
 
 ## Contributing

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -227,14 +227,28 @@ async function seed() {
   };
 
   if (await StartingSet.countDocuments() === 0) {
+    const inventorySets = {};
+    for (const race of races) {
+      inventorySets[race.code] = {};
+      for (const [cls, groups] of Object.entries(classInventory)) {
+        const arrays = Object.values(groups)
+          .filter(a => a.length)
+          .map(a => a.map(d => d.item));
+        const combos = combine(arrays).slice(0, 3);
+        inventorySets[race.code][cls] = combos;
+      }
+    }
+
     const sets = [];
-    for (const [cls, groups] of Object.entries(classInventory)) {
-      const arrays = Object.values(groups)
-        .filter(a => a.length)
-        .map(a => a.map(d => d.item));
-      const combos = combine(arrays);
-      for (const combo of combos) {
-        sets.push({ classCode: cls.toLowerCase(), items: combo.map(name => itemsByName[name]) });
+    for (const [raceCode, classes] of Object.entries(inventorySets)) {
+      for (const [cls, combos] of Object.entries(classes)) {
+        for (const combo of combos) {
+          sets.push({
+            raceCode,
+            classCode: cls.toLowerCase(),
+            items: combo.map(name => itemsByName[name])
+          });
+        }
       }
     }
     if (sets.length) {

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -37,7 +37,7 @@ exports.getAllByUser = async (req, res) => {
 exports.create = async (req, res) => {
   try {
 
-    let { name, description, image, gender, raceId, professionId } = req.body;
+    let { name, description, image, gender, raceId, professionId, race: raceCode, profession: professionCode } = req.body;
 
 
     if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 50) {

--- a/backend/src/models/StartingSet.js
+++ b/backend/src/models/StartingSet.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 require('./Item');
 
 const startingSetSchema = new mongoose.Schema({
+  raceCode: { type: String, required: true },
   classCode: { type: String, required: true },
   items: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Item' }]
 }, { timestamps: true });

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -17,7 +17,7 @@ function randomItem(list) {
 async function generateInventory(raceCode, classCode) {
   const result = [];
 
-  const sets = await StartingSet.find({ classCode }).populate('items');
+  const sets = await StartingSet.find({ classCode, raceCode }).populate('items');
   if (sets.length) {
     const selected = randomItem(sets);
     for (const item of selected.items) {

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -13,10 +13,13 @@ describe('generateInventory', () => {
 
   it('selects random items for each category', async () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
+    const spy = StartingSet.find;
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
 
     const items = await generateInventory('orc_male', 'warrior');
     Math.random.mockRestore();
+
+    expect(spy).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc_male' });
 
     expect(items).toEqual([
       { item: 'Меч', code: 'меч', amount: 1, bonus: {} },
@@ -28,10 +31,13 @@ describe('generateInventory', () => {
 
   it('mixes items across sets', async () => {
     StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
+    const spy2 = StartingSet.find;
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
     const items = await generateInventory('orc_female', 'warrior');
     Math.random.mockRestore();
+
+    expect(spy2).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc_female' });
 
     expect(items).toEqual([
       { item: 'Сокира', code: 'сокира', amount: 1, bonus: {} },

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -23,11 +23,18 @@ describe('seed script', () => {
     console.warn.mockRestore();
   });
 
-  it('creates starting sets for each class', async () => {
-    const codes = ['warrior','mage','archer','paladin','bard','healer'];
-    for (const code of codes) {
-      const count = await StartingSet.countDocuments({ classCode: code });
-      expect(count).toBeGreaterThan(0);
+  it('creates three sets for each race and class combination', async () => {
+    const races = [
+      'human_male','human_female','elf_male','elf_female',
+      'orc_male','orc_female','gnome_male','gnome_female',
+      'dwarf_male','dwarf_female'
+    ];
+    const classes = ['warrior','mage','archer','paladin','bard','healer'];
+    for (const r of races) {
+      for (const c of classes) {
+        const count = await StartingSet.countDocuments({ raceCode: r, classCode: c });
+        expect(count).toBe(3);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- require `raceCode` in the `StartingSet` model
- generate three starting sets for every race/class pair
- update `generateInventory` to use race when selecting a set
- fix controller bug with missing race and profession codes
- adjust tests for race+class inventory logic
- document new `inventorySets` behaviour

## Testing
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_68599ea53150832297184c93cfa4d5b0