### PR TITLE
Fix character creation form

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { createCharacter } from '../utils/api';
-import translateOrRaw from '../utils/translateOrRaw.js';
 
 const CharacterCreatePage = () => {
   const [name, setName] = useState('');
@@ -34,43 +33,6 @@ const CharacterCreatePage = () => {
           <option value="female">{t('gender.female')}</option>
         </select>
 
-        <select value={race} onChange={(e) => setRace(e.target.value)}>
-          <option value="wood_elf">
-            {translateOrRaw(t, 'races.wood_elf', 'Лісовий ельф')}
-          </option>
-          <option value="dark_elf">
-            {translateOrRaw(t, 'races.dark_elf', 'Темний ельф')}
-          </option>
-          <option value="human">
-            {translateOrRaw(t, 'races.human', 'Людина')}
-          </option>
-          <option value="halfling">
-            {translateOrRaw(t, 'races.halfling', 'Піврослик')}
-          </option>
-          <option value="lizardman">
-            {translateOrRaw(t, 'races.lizardman', 'Ящеролюдина')}
-          </option>
-        </select>
-        <select value={profession} onChange={(e) => setProfession(e.target.value)}>
-          <option value="warrior">
-            {translateOrRaw(t, 'classes.warrior', 'Воїн')}
-          </option>
-          <option value="paladin">
-            {translateOrRaw(t, 'classes.paladin', 'Паладин')}
-          </option>
-          <option value="wizard">
-            {translateOrRaw(t, 'classes.wizard', 'Маг')}
-          </option>
-          <option value="bard">{translateOrRaw(t, 'classes.bard', 'Бард')}</option>
-          <option value="assassin">
-            {translateOrRaw(t, 'classes.assassin', 'Асасін')}
-          </option>
-        </select>
-        <textarea
-          placeholder="Опис"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
         <button type="submit">{t('create_character')}</button>
 
       </form>


### PR DESCRIPTION
## Summary
- update character creation page to only ask name and gender
- remove unused imports and fields

## Testing
- `npm run lint` in `frontend`
- `npm test` in `frontend`
- `npm test` in `backend` *(fails: 6 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6859a89e81b88322b54a2e7a8f353dd1