### PR TITLE
Trim race list and handle gendered codes

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -25,7 +25,9 @@ export default function CharacterCard({
       ? character.profession
       : character.profession?.code || '';
   const genderCode = (character.gender || '').toLowerCase();
-  const raceKeyLower = (raceCode || '').toLowerCase();
+  const raceKeyLower = (raceCode || '')
+    .toLowerCase()
+    .replace(/_(male|female)$/, '');
   const classKeyLower = (classCode || '').toLowerCase();
   const raceName = character.race?.name || raceCode;
   const className = character.profession?.name || classCode;

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -22,7 +22,9 @@ export default function PlayerCard({ character, onSelect }) {
     typeof character.race === 'string'
       ? character.race
       : character.race?.code || '';
-  const raceKey = (raceCode || '').toLowerCase();
+  const raceKey = (raceCode || '')
+    .toLowerCase()
+    .replace(/_(male|female)$/, '');
   const raceName = character.race?.name || raceCode;
 
   const charClass =

--- a/frontend/src/components/PlayerStatusTable.jsx
+++ b/frontend/src/components/PlayerStatusTable.jsx
@@ -52,9 +52,12 @@ export default function PlayerStatusTable({ players, isGM, onEdit, onKick }) {
             typeof p.character?.race === 'string'
               ? p.character.race
               : p.character?.race?.code || '';
+          const raceKey = (raceCode || '')
+            .toLowerCase()
+            .replace(/_(male|female)$/, '');
           const race = translateOrRaw(
             t,
-            `races.${(raceCode || '').toLowerCase()}`,
+            `races.${raceKey}`,
             p.character?.race?.name || raceCode
           );
           const clsCode =

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4,21 +4,12 @@
     "female": "Female"
   },
   "races": {
-    "human_male": "Human (male)",
-    "human_female": "Human (female)",
-    "elf_male": "Elf (male)",
-    "elf_female": "Elf (female)",
-    "orc_male": "Orc (male)",
-    "orc_female": "Orc (female)",
-    "gnome_male": "Gnome (male)",
-    "gnome_female": "Gnome (female)",
-    "dwarf_male": "Dwarf (male)",
-    "dwarf_female": "Dwarf (female)",
+    "human": "Human",
     "wood_elf": "Wood Elf",
     "dark_elf": "Dark Elf",
-    "human": "Human",
-    "halfling": "Halfling",
-    "lizardman": "Lizardman"
+    "gnome": "Gnome",
+    "dwarf": "Dwarf",
+    "orc": "Orc"
   },
   "classes": {
     "warrior": "Warrior",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -4,21 +4,12 @@
     "female": "Жіноча"
   },
   "races": {
-    "human_male": "Людина (чоловік)",
-    "human_female": "Людина (жінка)",
-    "elf_male": "Ельф (чоловік)",
-    "elf_female": "Ельф (жінка)",
-    "orc_male": "Орк (чоловік)",
-    "orc_female": "Орк (жінка)",
-    "gnome_male": "Гном (чоловік)",
-    "gnome_female": "Гном (жінка)",
-    "dwarf_male": "Дварф (чоловік)",
-    "dwarf_female": "Дварф (жінка)",
+    "human": "Людина",
     "wood_elf": "Лісовий ельф",
     "dark_elf": "Темний ельф",
-    "human": "Людина",
-    "halfling": "Піврослик",
-    "lizardman": "Ящеролюдина"
+    "gnome": "Гном",
+    "dwarf": "Дварф",
+    "orc": "Орк"
   },
   "classes": {
     "warrior": "Воїн",

--- a/frontend/src/pages/CharacterListPage.jsx
+++ b/frontend/src/pages/CharacterListPage.jsx
@@ -24,7 +24,9 @@ export default function CharacterListPage() {
             typeof c.race === 'string'
               ? c.race
               : c.race?.code || '';
-          const raceKey = (raceCode || '').toLowerCase();
+          const raceKey = (raceCode || '')
+            .toLowerCase()
+            .replace(/_(male|female)$/, '');
           const raceText = raceCode
 
             ? translateOrRaw(t, `races.${raceKey}`, c.race?.name || raceCode)

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -129,7 +129,7 @@ export default function LobbyPage() {
                   <>{translateOrRaw(t, 'gender.' + character.gender.toLowerCase(), character.gender)} · </>
                 )}
                 {character.race?.code
-                  ? t(`races.${character.race.code.toLowerCase()}`)
+                  ? t(`races.${character.race.code.toLowerCase().replace(/_(male|female)$/, '')}`)
                   : (character.race?.name || '')} &middot;{' '}
                 {character.profession?.code
                   ? t(`classes.${character.profession.code.toLowerCase()}`)
@@ -154,7 +154,7 @@ export default function LobbyPage() {
                     )}
                     {pl.character.race && (
                       <> – {pl.character.race.code
-                        ? t(`races.${pl.character.race.code.toLowerCase()}`)
+                        ? t(`races.${pl.character.race.code.toLowerCase().replace(/_(male|female)$/, '')}`)
                         : (pl.character.race.name || '')}</>
                     )}
                     {pl.character.profession && (


### PR DESCRIPTION
## Summary
- update English and Ukrainian locale files to only include current race keys
- strip gender suffixes in race codes before translation in UI components

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859aec4fd508322a4330dd6ae77032f