### PR TITLE
Validate race and profession codes

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -8,6 +8,23 @@ const generateInventory = require('../utils/generateInventory');
 const generateAvatar = require('../utils/generateAvatar');
 const slug = require('../utils/slugify');
 
+const allowedRaceCodes = new Set([
+  'human',
+  'forest_elf',
+  'dark_elf',
+  'gnome',
+  'dwarf',
+  'orc'
+]);
+const allowedClassCodes = new Set([
+  'warrior',
+  'wizard',
+  'assassin',
+  'paladin',
+  'bard'
+]);
+const professionAliases = { mage: 'wizard' };
+
 function mapInventory(inv) {
   return (inv || []).map(it => ({
     item: it.item,
@@ -40,6 +57,10 @@ exports.create = async (req, res) => {
 
 
     let { name, description, image, gender, raceId, professionId, race: raceCode, profession: professionCode } = req.body;
+
+    if (professionAliases[professionCode]) {
+      professionCode = professionAliases[professionCode];
+    }
 
 
 
@@ -97,6 +118,15 @@ exports.create = async (req, res) => {
     return res.status(400).json({
       message: 'Missing races or professions to create character'
     });
+  }
+
+  const raceCodeValue = (race[0].code || '').toLowerCase();
+  const profCodeValue = (profession[0].code || '').toLowerCase();
+  if (!allowedRaceCodes.has(raceCodeValue)) {
+    return res.status(400).json({ message: 'Invalid race' });
+  }
+  if (!allowedClassCodes.has(profCodeValue)) {
+    return res.status(400).json({ message: 'Invalid class' });
   }
 
 

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -263,4 +263,32 @@ describe('Character Controller - create', () => {
     expect(saved.profession).toBe('p3');
     expect(res.status).toHaveBeenCalledWith(201);
   });
+
+  it('returns 400 for invalid race code', async () => {
+    Race.aggregate.mockResolvedValue([{ _id: 'r99', name: 'Alien', code: 'alien' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p1', name: 'Wizard', code: 'wizard' }]);
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
+
+    const req = { user: { id: 'u1' }, body: { name: 'Hero' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid race' });
+  });
+
+  it('returns 400 for invalid class code', async () => {
+    Race.aggregate.mockResolvedValue([{ _id: 'r1', name: 'Orc', code: 'orc' }]);
+    Profession.aggregate.mockResolvedValue([{ _id: 'p99', name: 'Pirate', code: 'pirate' }]);
+    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([{ items: [] }]) });
+
+    const req = { user: { id: 'u1' }, body: { name: 'Hero' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await characterController.create(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid class' });
+  });
 });


### PR DESCRIPTION
## Summary
- add allowed code lists for races and classes in the character controller
- verify race and profession codes and map `mage` to `wizard`
- test invalid race and profession codes are rejected

## Testing
- `npm test` *(fails: generateInventory.test.js, character.test.js, seed.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6859aec83c28832299c28bc4382cfd9a