### PR TITLE
Add translations for UI strings

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -24,5 +24,31 @@
   "welcome": "Welcome",
   "login": "Login",
   "password": "Password",
-  "create_character": "Create Character"
+  "create_character": "Create Character",
+  "back": "Back",
+  "your_characters": "Your Characters",
+  "create_new": "Create New",
+  "create_table": "Create Table",
+  "create_new_table": "Create New Table",
+  "gm_dashboard": "GM Dashboard",
+  "my_tables": "My Tables",
+  "open": "Open",
+  "no_tables": "No tables yet",
+  "empty_profile": "No characters yet",
+  "enter": "Enter",
+  "edit": "Edit",
+  "delete": "Delete",
+  "details": "Details",
+  "save": "Save",
+  "inventory": {
+    "title": "Inventory",
+    "empty": "Empty"
+  },
+  "unknown": "Unknown",
+  "name": "Name",
+  "gm_panel": "GM Panel",
+  "game_field": "Game Field",
+  "table": "Table",
+  "start_game": "Start Game",
+  "no_character": "No character"
 }

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -24,5 +24,31 @@
   "welcome": "Ласкаво просимо",
   "login": "Увійти",
   "password": "Пароль",
-  "create_character": "Створити персонажа"
+  "create_character": "Створити персонажа",
+  "back": "Назад",
+  "your_characters": "Ваші персонажі",
+  "create_new": "Створити новий",
+  "create_table": "Створити стіл",
+  "create_new_table": "Створити новий стіл",
+  "gm_dashboard": "Панель ГМа",
+  "my_tables": "Мої столи",
+  "open": "Відкрити",
+  "no_tables": "Немає столів",
+  "empty_profile": "Немає персонажів",
+  "enter": "Увійти",
+  "edit": "Редагувати",
+  "delete": "Видалити",
+  "details": "Деталі",
+  "save": "Зберегти",
+  "inventory": {
+    "title": "Інвентар", 
+    "empty": "Порожньо"
+  },
+  "unknown": "Невідомо",
+  "name": "Ім'я",
+  "gm_panel": "Панель ГМа",
+  "game_field": "Поле гри",
+  "table": "Стіл",
+  "start_game": "Почати гру",
+  "no_character": "Немає персонажа"
 }

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -24,7 +24,7 @@ const CharacterCreatePage = () => {
       <form onSubmit={handleSubmit}>
         <input
           type="text"
-          placeholder="Ім’я"
+          placeholder={t('name')}
           value={name}
           onChange={(e) => setName(e.target.value)}
         />


### PR DESCRIPTION
## Summary
- update translation files with more common keys
- use `t('name')` for name placeholder in CharacterCreatePage

## Testing
- `npm test --prefix frontend` *(fails: cross-env not found)*
- `npm run lint --prefix frontend` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859bbca50dc8322bc9f3257ca8f9779