### PR TITLE
Improve avatar generation fallback

### DIFF
--- a/backend/src/utils/generateAvatar.js
+++ b/backend/src/utils/generateAvatar.js
@@ -1,9 +1,34 @@
 const fs = require('fs');
 const path = require('path');
+const ai = require('./ai');
 
 async function generateAvatar(gender, raceCode, classCode) {
   try {
-    const avatarsDir = path.join(__dirname, '..', '..', '..', 'frontend', 'public', 'avatars');
+    const avatarsDir = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'frontend',
+      'public',
+      'avatars'
+    );
+
+    const specific = `${gender}_${raceCode}_${classCode}.png`;
+    const raceFile = `${gender}_${raceCode}.png`;
+
+    if (fs.existsSync(path.join(avatarsDir, specific))) {
+      return `/avatars/${specific}`;
+    }
+
+    if (fs.existsSync(path.join(avatarsDir, raceFile))) {
+      return `/avatars/${raceFile}`;
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+      return await ai.generateCharacterImage(`${gender} ${raceCode} ${classCode}`);
+    }
+
     const files = fs.readdirSync(avatarsDir).filter(f => !f.startsWith('.'));
     if (files.length === 0) return '';
     const file = files[Math.floor(Math.random() * files.length)];

--- a/backend/tests/generateAvatar.test.js
+++ b/backend/tests/generateAvatar.test.js
@@ -1,12 +1,46 @@
 const fs = require('fs');
+const ai = require('../src/utils/ai');
 const generateAvatar = require('../src/utils/generateAvatar');
 
 describe('generateAvatar', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    delete process.env.OPENAI_API_KEY;
   });
 
-  it('returns random avatar path', async () => {
+  it('returns specific avatar when file exists', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation(p =>
+      p.endsWith('male_elf_mage.png')
+    );
+
+    const path = await generateAvatar('male', 'elf', 'mage');
+
+    expect(path).toBe('/avatars/male_elf_mage.png');
+  });
+
+  it('returns race avatar when specific file missing', async () => {
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation(p => p.endsWith('male_elf.png'));
+
+    const path = await generateAvatar('male', 'elf', 'mage');
+
+    expect(path).toBe('/avatars/male_elf.png');
+  });
+
+  it('uses AI when files missing and API key set', async () => {
+    process.env.OPENAI_API_KEY = '1';
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(ai, 'generateCharacterImage').mockResolvedValue('/avatars/ai.png');
+
+    const path = await generateAvatar('male', 'elf', 'mage');
+
+    expect(ai.generateCharacterImage).toHaveBeenCalled();
+    expect(path).toBe('/avatars/ai.png');
+  });
+
+  it('returns random avatar path when no files and no API key', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
     jest.spyOn(fs, 'readdirSync').mockReturnValue(['a.png', 'b.png']);
 
     const path = await generateAvatar('male', 'elf', 'mage');
@@ -14,7 +48,8 @@ describe('generateAvatar', () => {
     expect(path.startsWith('/avatars/')).toBe(true);
   });
 
-  it('returns empty string when no files', async () => {
+  it('returns empty string when avatar folder empty', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
     jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 
     const path = await generateAvatar('male', 'elf', 'mage');


### PR DESCRIPTION
## Summary
- add custom avatar lookup in `generateAvatar`
- test fallback logic for existing assets and AI generation

## Testing
- `npm test tests/generateAvatar.test.js`
- `npm test` *(fails: generateInventory.test.js, character.test.js, seed.test.js, socket.startGame.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6859bbcb67248322a4f37078af0c8e11