### PR TITLE
Add unknown translation fallback

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -24,5 +24,6 @@
   "welcome": "Welcome",
   "login": "Login",
   "password": "Password",
-  "create_character": "Create Character"
+  "create_character": "Create Character",
+  "unknown": "Unknown"
 }

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -24,5 +24,6 @@
   "welcome": "Ласкаво просимо",
   "login": "Увійти",
   "password": "Пароль",
-  "create_character": "Створити персонажа"
+  "create_character": "Створити персонажа",
+  "unknown": "Невідомо"
 }

--- a/frontend/tests/i18nFallback.test.cjs
+++ b/frontend/tests/i18nFallback.test.cjs
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+
+let en, ua, translateOrRaw;
+beforeAll(async () => {
+  ({ default: translateOrRaw } = await import('../src/utils/translateOrRaw.js'));
+  ({ default: en } = await import('../src/locales/en.json', { assert: { type: 'json' } }));
+  ({ default: ua } = await import('../src/locales/ua.json', { assert: { type: 'json' } }));
+});
+
+function makeT(data) {
+  return (key) => key.split('.').reduce((o, p) => (o || {})[p], data) ?? key;
+}
+
+test('english missing key uses unknown translation', () => {
+  const t = makeT(en);
+  expect(translateOrRaw(t, 'stats.missing')).toBe(en.unknown);
+});
+
+test('ukrainian missing key uses unknown translation', () => {
+  const t = makeT(ua);
+  expect(translateOrRaw(t, 'stats.missing')).toBe(ua.unknown);
+});


### PR DESCRIPTION
## Summary
- add `unknown` key to `en.json` and `ua.json`
- test i18n fallback uses the translation from each locale

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859bbcbf7dc8322ba1d218fadaa82e3