### PR TITLE
Improve dependency setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This project combines an Express/MongoDB backend with a React frontend.
    ```bash
    ./setup.sh
    ```
+
+   This installs tools like `cross-env`, **Jest** and **ESLint** used by the
+   project. Attempting `npm run lint` or `npm test` before running this script
+   will fail with "command not found" errors.
+
    You may optionally run `npm audit fix --force` inside `backend` and
    `frontend` to address any security warnings.
 


### PR DESCRIPTION
## Summary
- clarify what `setup.sh` installs
- warn that skipping it breaks `npm run lint` and `npm test`

## Testing
- `./setup.sh`
- `npm run lint` in `backend` *(fails: many prettier errors)*
- `npm test` in `backend` *(fails: tests fail)*
- `npm run lint` in `frontend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859bbcf45ec8322a1838ed9f3628263