### PR TITLE
Set Ukrainian as default language

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,7 +5,12 @@ import App from './App';
 import { SettingsProvider } from './context/SettingsContext';
 import { ToastProvider } from './context/ToastContext';
 import AxiosToastProvider from './components/AxiosToastProvider';
-import './i18n';
+import i18n from './i18n';
+
+// Set Ukrainian as the default language on first load
+if (!localStorage.getItem('lang')) {
+  i18n.changeLanguage('ua');
+}
 import './index.css';
 import './App.css';
 


### PR DESCRIPTION
## Summary
- set UA as default language on first load

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend` *(fails: Character Controller - create / seed script)*
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859c22c62408322893bc4d66001dc78