### PR TITLE
Localize navbar links

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import LanguageSwitch from './LanguageSwitch';
 import ThemeToggle from './ThemeToggle';
 
@@ -7,6 +8,7 @@ function Navbar() {
   const navigate = useNavigate();
   const token = localStorage.getItem("token");
   const user = JSON.parse(localStorage.getItem("user") || "null");
+  const { t } = useTranslation();
 
   const handleLogout = () => {
     localStorage.removeItem("token");
@@ -21,11 +23,11 @@ function Navbar() {
         <span className="font-dnd text-2xl">D-DUA</span>
       </Link>
       <div className="flex items-center gap-4 flex-1">
-        <Link to="/characters" className="hover:text-white">Profile</Link>
-        <Link to="/settings" className="hover:text-white">Settings</Link>
+        <Link to="/characters" className="hover:text-white">{t('profile')}</Link>
+        <Link to="/settings" className="hover:text-white">{t('settings')}</Link>
         {token && (
           <button onClick={handleLogout} className="text-dndred hover:text-dndgold">
-            Logout
+            {t('logout')}
           </button>
         )}
         <Link to="/settings" className="text-sm hover:underline">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -25,6 +25,9 @@
   "login": "Login",
   "password": "Password",
   "create_character": "Create Character",
+  "profile": "Profile",
+  "settings": "Settings",
+  "logout": "Logout",
 
   "unknown": "Unknown"
 

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -25,6 +25,9 @@
   "login": "Увійти",
   "password": "Пароль",
   "create_character": "Створити персонажа",
+  "profile": "Профіль",
+  "settings": "Налаштування",
+  "logout": "Вийти",
 
   "unknown": "Невідомо"
 


### PR DESCRIPTION
## Summary
- add translation support to Navbar
- add `profile`, `settings`, `logout` to locales

## Testing
- `./setup.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859c22f68d8832285d0dba1c837cbef