### PR TITLE
Improve character creation page style

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -14,27 +14,47 @@ const CharacterCreatePage = () => {
     e.preventDefault();
     const newChar = await createCharacter({ name, gender });
     if (newChar && newChar._id) {
-      navigate('/lobby?char=' + newChar._id);
+      navigate('/characters');
     }
   };
 
   return (
-    <div className="character-create-page">
-      <h2>{t('create_character')}</h2>
-      <form onSubmit={handleSubmit}>
+    <div
+      className="relative min-h-screen bg-dndbg bg-cover bg-center flex flex-col items-center justify-center p-6 font-dnd text-dndgold text-shadow"
+      style={{ backgroundImage: "url('/map-bg.jpg')" }}
+    >
+      <div className="absolute top-4 left-4">
+        <button
+          onClick={() => navigate('/characters')}
+          className="bg-dndgold hover:bg-dndred text-dndred hover:text-white font-dnd rounded-2xl px-4 py-2 transition active:scale-95"
+        >
+          {t('back')}
+        </button>
+      </div>
+      <h2 className="text-2xl mb-4">{t('create_character')}</h2>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 items-center">
         <input
           type="text"
           placeholder={t('name')}
           value={name}
           onChange={(e) => setName(e.target.value)}
+          className="p-2 rounded bg-[#3c2a20] text-white placeholder:text-gray-300 w-64"
         />
-        <select value={gender} onChange={(e) => setGender(e.target.value)}>
+        <select
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+          className="p-2 rounded bg-gray-700 text-white w-64"
+        >
           <option value="male">{t('gender.male')}</option>
           <option value="female">{t('gender.female')}</option>
         </select>
 
-        <button type="submit">{t('create_character')}</button>
-
+        <button
+          type="submit"
+          className="bg-dndgold text-dndred rounded-2xl px-4 py-2 font-semibold transition active:scale-95"
+        >
+          {t('create_character')}
+        </button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle character creation page like ProfilePage
- add "Back" button to return to `/characters`
- redirect to `/characters` after creating a new character

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae3b498c88322916777f9d94be0bf