### PR TITLE
Use Axios in frontend utils

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,99 +1,50 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
-
-const getAuthHeaders = () => {
-  const token = localStorage.getItem('token');
-  const headers = { Authorization: `Bearer ${token}` };
-  return headers;
-};
+import api from '../api/axios';
 
 export const getCharacters = async () => {
-  const res = await fetch(`${API_URL}/character`, {
-    headers: getAuthHeaders(),
-  });
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  const res = await api.get('/character');
+  return res.data;
 };
 
 export const getCharacter = async (id) => {
-  const res = await fetch(`${API_URL}/character/${id}`, {
-    headers: getAuthHeaders(),
-  });
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  const res = await api.get(`/character/${id}`);
+  return res.data;
 };
 
 export const createCharacter = async (data) => {
-  const headers = getAuthHeaders();
-  let body;
+  let payload = data;
   if (data.image instanceof File) {
-    body = new FormData();
-    Object.keys(data).forEach(key => {
-      if (data[key] !== undefined) body.append(key, data[key]);
+    payload = new FormData();
+    Object.keys(data).forEach((key) => {
+      if (data[key] !== undefined) payload.append(key, data[key]);
     });
-  } else {
-    headers['Content-Type'] = 'application/json';
-    body = JSON.stringify(data);
   }
-  const res = await fetch(`${API_URL}/character`, {
-    method: 'POST',
-    headers,
-    body,
-  });
-  if (!res.ok) {
-    const msg = await res.text();
-    throw new Error(msg || res.statusText);
-  }
-  return res.json();
+  const res = await api.post('/character', payload);
+  return res.data;
 };
 
 export const deleteCharacter = async (id) => {
-  const res = await fetch(`${API_URL}/character/${id}`, {
-    method: 'DELETE',
-    headers: getAuthHeaders(),
-  });
-  return res.json();
+  const res = await api.delete(`/character/${id}`);
+  return res.data;
 };
 
 export const updateCharacter = async (id, data) => {
-  const headers = getAuthHeaders();
-  let body;
+  let payload = data;
   if (data.image instanceof File) {
-    body = new FormData();
-    Object.keys(data).forEach(key => {
-      if (data[key] !== undefined) body.append(key, data[key]);
+    payload = new FormData();
+    Object.keys(data).forEach((key) => {
+      if (data[key] !== undefined) payload.append(key, data[key]);
     });
-  } else {
-    headers['Content-Type'] = 'application/json';
-    body = JSON.stringify(data);
   }
-  const res = await fetch(`${API_URL}/character/${id}`, {
-    method: 'PUT',
-    headers,
-    body,
-  });
-  return res.json();
+  const res = await api.put(`/character/${id}`, payload);
+  return res.data;
 };
 
 export const getRaces = async () => {
-  const res = await fetch(`${API_URL}/race`, {
-    headers: getAuthHeaders(),
-  });
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  const res = await api.get('/race');
+  return res.data;
 };
 
 export const getProfessions = async () => {
-  const res = await fetch(`${API_URL}/profession`, {
-    headers: getAuthHeaders(),
-  });
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  const res = await api.get('/profession');
+  return res.data;
 };


### PR DESCRIPTION
## Summary
- refactor `frontend/src/utils/api.js` to reuse existing Axios instance

## Testing
- `npm test` within `frontend`
- `npm test` within `backend` *(fails: generateInventory, character controller, seed script)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3b7b0f8832287ac703891fc4515