### PR TITLE
Add AI avatar fetch on character creation

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { createCharacter } from '../utils/api';
+import api from '../api/axios';
 import { getRandomElement } from '../utils/characterUtils';
 
 const raceOptions = ['human', 'forest_elf', 'dark_elf', 'gnome', 'dwarf', 'orc'];
@@ -20,11 +21,21 @@ const CharacterCreatePage = () => {
     e.preventDefault();
     const finalRace = race || getRandomElement(raceOptions);
     const finalProfession = profession || getRandomElement(classOptions);
+    let avatarUrl = '';
+    try {
+      const desc = `${gender} ${finalRace} ${finalProfession}`;
+      const res = await api.post('/ai/avatar', { description: desc });
+      avatarUrl = res.data?.url || '';
+    } catch {
+      avatarUrl = '';
+    }
+
     const newChar = await createCharacter({
       name,
       gender,
       race: finalRace,
       profession: finalProfession,
+      avatar: avatarUrl,
     });
     if (newChar && newChar._id) {
       navigate('/characters');


### PR DESCRIPTION
## Summary
- fetch an avatar from `/ai/avatar` before submitting a new character
- submit the fetched URL as `avatar` when creating the character

## Testing
- `./setup.sh`
- `npm test` within `backend` *(fails: generateInventory, character controller and seed tests)*
- `npm test` within `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685af350cd808322b65bcfa0b4600f7c