### PR TITLE
Update tests for new alias codes

### DIFF
--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -19,7 +19,7 @@ describe('generateInventory', () => {
     const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    expect(spy).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc_male' });
+    expect(spy).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc' });
 
     expect(items).toEqual([
       { item: 'Меч', code: 'меч', amount: 1, bonus: {} },
@@ -37,7 +37,7 @@ describe('generateInventory', () => {
     const items = await generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    expect(spy2).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc_female' });
+    expect(spy2).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc' });
 
     expect(items).toEqual([
       { item: 'Сокира', code: 'сокира', amount: 1, bonus: {} },

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -26,11 +26,9 @@ describe('seed script', () => {
 
   it('creates three sets for each race and class combination', async () => {
     const races = [
-      'human_male','human_female','elf_male','elf_female',
-      'orc_male','orc_female','gnome_male','gnome_female',
-      'dwarf_male','dwarf_female'
+      'human','forest_elf','dark_elf','gnome','dwarf','orc'
     ];
-    const classes = ['warrior','mage','archer','paladin','bard','healer'];
+    const classes = ['warrior','mage','assassin','paladin','bard'];
     for (const r of races) {
       for (const c of classes) {
         const count = await StartingSet.countDocuments({ raceCode: r, classCode: c });


### PR DESCRIPTION
## Summary
- fix unit tests for updated profession aliases and race codes
- handle wizard aliasing in tests
- adjust seed test for new allowed codes

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685af35228d88322a0af8cf37246920f