### PR TITLE
Load race & class options for character creation

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,22 +1,45 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { createCharacter } from '../utils/api';
+import { createCharacter, getRaces, getProfessions } from '../utils/api';
 import api from '../api/axios';
 import { getRandomElement } from '../utils/characterUtils';
+import translateOrRaw from '../utils/translateOrRaw.js';
 
 const CharacterCreatePage = () => {
   const [name, setName] = useState('');
   const [gender, setGender] = useState('male');
+  const [race, setRace] = useState('');
+  const [profession, setProfession] = useState('');
+  const [raceOptions, setRaceOptions] = useState([]);
+  const [classOptions, setClassOptions] = useState([]);
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    const fetchOptions = async () => {
+      try {
+        const races = await getRaces();
+        setRaceOptions(races);
+      } catch {
+        setRaceOptions([]);
+      }
+      try {
+        const professions = await getProfessions();
+        setClassOptions(professions);
+      } catch {
+        setClassOptions([]);
+      }
+    };
+    fetchOptions();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const finalRace = race || getRandomElement(raceOptions);
-    const finalProfession = profession || getRandomElement(classOptions);
+    const finalRace = race || (getRandomElement(raceOptions) || {}).code;
+    const finalProfession = profession || (getRandomElement(classOptions) || {}).code;
     let avatarUrl = '';
     try {
       const desc = `${gender} ${finalRace} ${finalProfession}`;
@@ -30,7 +53,7 @@ const CharacterCreatePage = () => {
       name,
       gender,
       race: finalRace,
-      profession: finalProfession,
+      class: finalProfession,
       avatar: avatarUrl,
 
     });
@@ -68,6 +91,32 @@ const CharacterCreatePage = () => {
         >
           <option value="male">{t('gender.male')}</option>
           <option value="female">{t('gender.female')}</option>
+        </select>
+
+        <select
+          value={race}
+          onChange={(e) => setRace(e.target.value)}
+          className="p-2 rounded bg-gray-700 text-white w-64"
+        >
+          <option value="">{t('random')}</option>
+          {raceOptions.map((r) => (
+            <option key={r._id} value={r.code}>
+              {translateOrRaw(t, `races.${r.code.toLowerCase()}`, r.name)}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={profession}
+          onChange={(e) => setProfession(e.target.value)}
+          className="p-2 rounded bg-gray-700 text-white w-64"
+        >
+          <option value="">{t('random')}</option>
+          {classOptions.map((c) => (
+            <option key={c._id} value={c.code}>
+              {translateOrRaw(t, `classes.${c.code.toLowerCase()}`, c.name)}
+            </option>
+          ))}
         </select>
 
         <button


### PR DESCRIPTION
## Summary
- add state for race and profession selections
- fetch available races and professions from the API
- populate dropdowns with translated labels
- use the chosen or random race/profession when creating a character

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3cf9b25083229880970ad382a61b