### PR TITLE
Implement AI-generated description route

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ version before continuing.
    - `JWT_SECRET` – secret used for signing tokens
    - `PORT` – optional server port (defaults to `5000`)
    - `CLIENT_URL` – allowed origin(s) for CORS. Set this to the URL of your frontend (comma separated to allow multiple, e.g. `http://localhost:5173,https://example.com`).
+   - `OPENAI_API_KEY` – optional key used to generate avatars and character descriptions via OpenAI APIs.
 
    Create a `.env` file inside `frontend` with the following keys:
    - `VITE_API_URL` – base URL of the backend API (e.g. `http://localhost:5000/api`).
@@ -63,6 +64,7 @@ npm run dev
 ```
 
 The backend automatically creates `uploads/` and `uploads/maps/` directories for uploaded files and exposes them from the `/uploads` path. Preset avatars are served from `/avatars`.
+An additional endpoint `POST /api/ai/description` returns a short character description when `OPENAI_API_KEY` is configured.
 
 ### Frontend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ MONGO_URI=mongodb://localhost:27017/ddua
 JWT_SECRET=your_jwt_secret
 PORT=5000
 CLIENT_URL=http://localhost:5173
+OPENAI_API_KEY=

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,12 +1,25 @@
 const express = require('express');
 const router = express.Router();
-const { generateCharacterImage } = require('../utils/ai');
+const {
+  generateCharacterImage,
+  generateCharacterDescription,
+} = require('../utils/ai');
 
 router.post('/avatar', async (req, res) => {
   const { description } = req.body;
   try {
     const url = await generateCharacterImage(description || 'fantasy character');
     res.json({ url });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'AI service error' });
+  }
+});
+
+router.post('/description', async (req, res) => {
+  try {
+    const desc = await generateCharacterDescription(req.body || {});
+    res.json({ description: desc });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'AI service error' });

--- a/backend/src/utils/ai.js
+++ b/backend/src/utils/ai.js
@@ -44,9 +44,29 @@ exports.generateCharacterImage = async (description) => {
   return `/uploads/avatars/${filename}`;
 };
 
-exports.generateCharacterDescription = async (params) => {
-  void params;
-  // Можна підключити ChatGPT або інший сервіс
-  // ...
-  return 'Короткий опис персонажа з AI';
+exports.generateCharacterDescription = async ({ raceCode = '', classCode = '', gender = '' } = {}) => {
+  if (!process.env.OPENAI_API_KEY) return '';
+
+  const prompt =
+    `Give a short fantasy character description. ` +
+    `Race: ${raceCode}. Class: ${classCode}. Gender: ${gender}.`;
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 60,
+      }),
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content?.trim() || '';
+  } catch {
+    return '';
+  }
 };

--- a/backend/tests/ai.test.js
+++ b/backend/tests/ai.test.js
@@ -2,7 +2,8 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../src/utils/ai', () => ({
-  generateCharacterImage: jest.fn().mockResolvedValue('http://image.test/avatar.png')
+  generateCharacterImage: jest.fn().mockResolvedValue('http://image.test/avatar.png'),
+  generateCharacterDescription: jest.fn().mockResolvedValue('A brave hero'),
 }));
 
 const aiRouter = require('../src/routes/ai');
@@ -17,6 +18,14 @@ describe('AI Routes', () => {
       const res = await request(app).post('/api/ai/avatar').send({ description: 'hero' });
       expect(res.statusCode).toBe(200);
       expect(res.body.url).toBe('http://image.test/avatar.png');
+    });
+  });
+
+  describe('POST /api/ai/description', () => {
+    it('should return generated description', async () => {
+      const res = await request(app).post('/api/ai/description').send({ raceCode: 'elf' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body.description).toBe('A brave hero');
     });
   });
 });


### PR DESCRIPTION
## Summary
- integrate OpenAI chat completion in `generateCharacterDescription`
- expose new `POST /api/ai/description` route
- test the new endpoint
- document `OPENAI_API_KEY` and the new route
- update `.env.example` with OpenAI key placeholder

## Testing
- `./setup.sh`
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685d3cfe48ec8322903aaf5b91622c7d