### PR TITLE
Fix GM redirect on character creation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -58,7 +58,10 @@ const App = () => {
       <Route path="/ping" element={<div>ok</div>} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/characters" element={isAuthenticated() ? <ProfilePage /> : <Navigate to="/login" />} />
-      <Route path="/create-character" element={isAuthenticated() ? <CharacterCreatePage /> : <Navigate to="/login" />} />
+      <Route
+        path="/create-character"
+        element={isAuthenticated() ? (isGM() ? <Navigate to="/gm-dashboard" /> : <CharacterCreatePage />) : <Navigate to="/login" />}
+      />
       <Route path="/lobby" element={isAuthenticated() ? <LobbyPage /> : <Navigate to="/login" />} />
       <Route path="/admin" element={isAdmin() ? <AdminPage /> : <Navigate to="/admin/login" />} />
       <Route path="/admin/inventory/:characterId" element={isAdmin() ? <AdminInventoryPage /> : <Navigate to="/admin/login" />} />

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -7,6 +7,7 @@ import api from '../api/axios';
 import { getRandomElement } from '../utils/characterUtils';
 
 import { useAppearance } from '../context/AppearanceContext';
+import { getStoredUserRole } from '../utils/auth';
 
 
 const CharacterCreatePage = () => {
@@ -18,6 +19,12 @@ const CharacterCreatePage = () => {
   const [classOptions, setClassOptions] = useState([]);
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (getStoredUserRole() === 'gm') {
+      navigate('/gm-dashboard');
+    }
+  }, [navigate]);
 
   useEffect(() => {
     const fetchOptions = async () => {

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -34,7 +34,13 @@ const ProfilePage = () => {
     fetchChars();
   }, []);
 
-  const handleCreate = () => navigate('/create-character');
+  const handleCreate = () => {
+    if (user?.role === 'gm') {
+      navigate('/gm-dashboard');
+    } else {
+      navigate('/create-character');
+    }
+  };
   const handleSelect = (charId) => navigate(`/lobby?char=${charId}`);
   const handleDelete = async (id) => {
     await deleteCharacter(id);

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,0 +1,8 @@
+export const getStoredUserRole = () => {
+  try {
+    const data = JSON.parse(localStorage.getItem('user-storage') || '{}');
+    return data.state?.user?.role || null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- detect stored user role in CharacterCreatePage and redirect GMs
- centralize role lookup with new `getStoredUserRole` util
- prevent GMs from opening create page through profile button
- route `/create-character` to `/gm-dashboard` when role is gm

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d8357d6d08322a6565f6478e01f53