### PR TITLE
Remove AI character description route

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ version before continuing.
    - `JWT_SECRET` – secret used for signing tokens
    - `PORT` – optional server port (defaults to `5000`)
    - `CLIENT_URL` – allowed origin(s) for CORS. Set this to the URL of your frontend (comma separated to allow multiple, e.g. `http://localhost:5173,https://example.com`).
-   - `OPENAI_API_KEY` – optional key used to generate avatars and character descriptions via OpenAI APIs.
+  - `OPENAI_API_KEY` – optional key used to generate avatars via OpenAI APIs.
 
    Create a `.env` file inside `frontend` with the following keys:
    - `VITE_API_URL` – base URL of the backend API (e.g. `http://localhost:5000/api`).
@@ -64,7 +64,6 @@ npm run dev
 ```
 
 The backend automatically creates `uploads/` and `uploads/maps/` directories for uploaded files and exposes them from the `/uploads` path. Preset avatars are served from `/avatars`.
-An additional endpoint `POST /api/ai/description` returns a short character description when `OPENAI_API_KEY` is configured.
 
 ### Frontend
 

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,25 +1,12 @@
 const express = require('express');
 const router = express.Router();
-const {
-  generateCharacterImage,
-  generateCharacterDescription,
-} = require('../utils/ai');
+const { generateCharacterImage } = require('../utils/ai');
 
 router.post('/avatar', async (req, res) => {
   const { description } = req.body;
   try {
     const url = await generateCharacterImage(description || 'fantasy character');
     res.json({ url });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'AI service error' });
-  }
-});
-
-router.post('/description', async (req, res) => {
-  try {
-    const desc = await generateCharacterDescription(req.body || {});
-    res.json({ description: desc });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'AI service error' });

--- a/backend/src/utils/ai.js
+++ b/backend/src/utils/ai.js
@@ -43,30 +43,3 @@ exports.generateCharacterImage = async (description) => {
   fs.writeFileSync(path.join(dir, filename), buffer);
   return `/uploads/avatars/${filename}`;
 };
-
-exports.generateCharacterDescription = async ({ raceCode = '', classCode = '', gender = '' } = {}) => {
-  if (!process.env.OPENAI_API_KEY) return '';
-
-  const prompt =
-    `Give a short fantasy character description. ` +
-    `Race: ${raceCode}. Class: ${classCode}. Gender: ${gender}.`;
-
-  try {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: prompt }],
-        max_tokens: 60,
-      }),
-    });
-    const data = await res.json();
-    return data.choices?.[0]?.message?.content?.trim() || '';
-  } catch {
-    return '';
-  }
-};

--- a/backend/tests/ai.test.js
+++ b/backend/tests/ai.test.js
@@ -3,7 +3,6 @@ const express = require('express');
 
 jest.mock('../src/utils/ai', () => ({
   generateCharacterImage: jest.fn().mockResolvedValue('http://image.test/avatar.png'),
-  generateCharacterDescription: jest.fn().mockResolvedValue('A brave hero'),
 }));
 
 const aiRouter = require('../src/routes/ai');
@@ -21,11 +20,4 @@ describe('AI Routes', () => {
     });
   });
 
-  describe('POST /api/ai/description', () => {
-    it('should return generated description', async () => {
-      const res = await request(app).post('/api/ai/description').send({ raceCode: 'elf' });
-      expect(res.statusCode).toBe(200);
-      expect(res.body.description).toBe('A brave hero');
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- drop `generateCharacterDescription` util
- remove `/api/ai/description` route and tests
- clean up README

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d8356347483229631c1c93edfb8b2