### PR TITLE
Fix register page fallback translation

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -51,6 +51,7 @@
   "admin": "Admin",
   "register": "Register",
   "register_submit": "Register",
+  "register_error": "Registration error",
   "fields_required": "All fields required",
   "back": "Back",
   "your_characters": "Your Characters",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -51,6 +51,7 @@
   "admin": "Адмін",
   "register": "Реєстрація",
   "register_submit": "Зареєструватися",
+  "register_error": "Помилка реєстрації",
   "fields_required": "Всі поля обов'язкові",
   "back": "Назад",
   "your_characters": "Ваші персонажі",

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -34,7 +34,7 @@ function RegisterPage() {
       localStorage.setItem("user", JSON.stringify(response.data.user));
       navigate("/");
     } catch (err) {
-      setError(err.response?.data?.message || "Помилка реєстрації");
+      setError(err.response?.data?.message || t('register_error'));
     }
   };
 


### PR DESCRIPTION
## Summary
- replace Ukrainian fallback text with `t('register_error')`
- add `register_error` translation for EN/UA

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d8aa0d1f48322894a3734be9327f2