### PR TITLE
Localize admin page

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -47,6 +47,22 @@
   "add": "Add",
   "listen": "Listen",
 
+  "admin_page_title": "Admin Panel",
+  "set_music": "Set Music",
+  "create_new_race": "Create New Race",
+  "upload_map": "Upload Map",
+  "users": "Users",
+  "appearance": "Appearance",
+  "start_session": "Start Session",
+  "end_session": "End Session",
+  "race_list": "Race List",
+  "event_log": "Event Log",
+  "confirm_delete_race": "Are you sure you want to delete this race?",
+  "youtube_link_prompt": "Paste YouTube link:",
+  "race_name_prompt": "Race name:",
+  "session_started": "Session started",
+  "session_ended": "Session ended",
+
 
   "admin": "Admin",
   "register": "Register",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -47,6 +47,22 @@
   "add": "Додати",
   "listen": "Послухати",
 
+  "admin_page_title": "Панель Адміністратора",
+  "set_music": "Встановити музику",
+  "create_new_race": "Створити нову расу",
+  "upload_map": "Завантажити карту",
+  "users": "Користувачі",
+  "appearance": "Оформлення",
+  "start_session": "Запустити сесію",
+  "end_session": "Завершити сесію",
+  "race_list": "Список рас",
+  "event_log": "Журнал подій",
+  "confirm_delete_race": "Ви впевнені, що хочете видалити цю расу?",
+  "youtube_link_prompt": "Вставте YouTube посилання:",
+  "race_name_prompt": "Назва раси:",
+  "session_started": "Сесія запущена",
+  "session_ended": "Сесію завершено",
+
 
   "admin": "Адмін",
   "register": "Реєстрація",

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import AdminCard from "../components/AdminCard";
 import { useNavigate } from "react-router-dom";
 import { useAppearance } from '../context/AppearanceContext';
+import { useTranslation } from 'react-i18next';
 import {
   setMusic,
   createRace,
@@ -18,6 +19,7 @@ export default function AdminPage() {
   const [races, setRaces] = useState([]);
   const [log, setLog] = useState([]);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     getRaces().then((res) => {
@@ -35,7 +37,7 @@ export default function AdminPage() {
   };
 
   const handleSetMusic = async () => {
-    const url = prompt("Вставте YouTube посилання:");
+    const url = prompt(t('youtube_link_prompt'));
     if (url) {
       await setMusic(url);
       const id = url.split("v=")[1]?.split("&")[0] || null;
@@ -44,7 +46,7 @@ export default function AdminPage() {
   };
 
   const handleCreateRace = async () => {
-    const name = prompt("Назва раси:");
+    const name = prompt(t('race_name_prompt'));
     if (name) {
       await createRace({ name });
       refreshRaces();
@@ -66,7 +68,7 @@ export default function AdminPage() {
   };
 
   const handleDeleteRace = async (id) => {
-    if (window.confirm("Ви впевнені, що хочете видалити цю расу?")) {
+    if (window.confirm(t('confirm_delete_race'))) {
       await deleteRace(id);
       refreshRaces();
     }
@@ -74,12 +76,12 @@ export default function AdminPage() {
 
   const handleStartSession = async () => {
     await startSession();
-    alert("Сесія запущена");
+    alert(t('session_started'));
   };
 
   const handleEndSession = async () => {
     await endSession();
-    alert("Сесію завершено");
+    alert(t('session_ended'));
   };
 
   const { background } = useAppearance();
@@ -88,26 +90,26 @@ export default function AdminPage() {
       className="min-h-screen bg-cover bg-center p-8 font-dnd text-white"
       style={{ backgroundImage: `url('${background}')` }}
     >
-      <h1 className="text-3xl text-dndgold mb-6">Панель Адміністратора</h1>
+      <h1 className="text-3xl text-dndgold mb-6">{t('admin_page_title')}</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <AdminCard title="Встановити музику" onClick={handleSetMusic} />
-        <AdminCard title="Створити нову расу" onClick={handleCreateRace} />
-        <AdminCard title="Завантажити карту" onClick={handleUploadMap} />
-        <AdminCard title="Користувачі" onClick={() => navigate('/admin/users')} />
-        <AdminCard title="Оформлення" onClick={() => navigate('/admin/appearance')} />
-        <AdminCard title="Запустити сесію" onClick={handleStartSession} />
-        <AdminCard title="Завершити сесію" onClick={handleEndSession} />
+        <AdminCard title={t('set_music')} onClick={handleSetMusic} />
+        <AdminCard title={t('create_new_race')} onClick={handleCreateRace} />
+        <AdminCard title={t('upload_map')} onClick={handleUploadMap} />
+        <AdminCard title={t('users')} onClick={() => navigate('/admin/users')} />
+        <AdminCard title={t('appearance')} onClick={() => navigate('/admin/appearance')} />
+        <AdminCard title={t('start_session')} onClick={handleStartSession} />
+        <AdminCard title={t('end_session')} onClick={handleEndSession} />
       </div>
 
       <div className="mb-6">
-        <h2 className="text-xl text-dndgold mb-2">Список рас</h2>
+        <h2 className="text-xl text-dndgold mb-2">{t('race_list')}</h2>
         <ul className="list-disc pl-6 text-base space-y-1">
           {races.map((r) => (
             <li key={r._id} className="flex justify-between items-center">
               {r.name}
               <button onClick={() => handleDeleteRace(r._id)} className="ml-2 text-red-500 hover:underline">
-                Видалити
+                {t('delete')}
               </button>
             </li>
           ))}
@@ -116,7 +118,7 @@ export default function AdminPage() {
 
       {log.length > 0 && (
         <div className="mt-6">
-          <h2 className="text-xl text-dndgold mb-2">Журнал подій</h2>
+          <h2 className="text-xl text-dndgold mb-2">{t('event_log')}</h2>
           <ul className="list-disc pl-6 text-base space-y-1">
             {log.map((entry, i) => (
               <li key={i}>{entry}</li>


### PR DESCRIPTION
## Summary
- use translation keys on AdminPage
- add English and Ukrainian translations for admin UI strings

## Testing
- `./setup.sh`
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685d8aa169ec8322886b3b33b0a5f038