### PR TITLE
Fix localization and tests

### DIFF
--- a/backend/tests/socket.sync.test.js
+++ b/backend/tests/socket.sync.test.js
@@ -20,7 +20,7 @@ afterAll((done) => {
   httpServer.close(done);
 });
 
-jest.setTimeout(10000);
+jest.setTimeout(15000);
 
 test('GM updates propagate to players', (done) => {
   const url = `http://localhost:${addr.port}`;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
 
     "prelint": "node ../scripts/check-node-modules.js",
-    "lint": "eslint -c eslint.config.cjs src"
+    "lint": "eslint . --config eslint.config.cjs"
 
 
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -69,6 +69,7 @@
   "register": "Register",
   "register_submit": "Register",
   "register_error": "Registration error",
+  "user_already_exists": "User already exists",
   "fields_required": "All fields required",
   "back": "Back",
   "your_characters": "Your Characters",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -69,6 +69,7 @@
   "register": "Реєстрація",
   "register_submit": "Зареєструватися",
   "register_error": "Помилка реєстрації",
+  "user_already_exists": "Такий користувач вже існує",
   "fields_required": "Всі поля обов'язкові",
   "back": "Назад",
   "your_characters": "Ваші персонажі",

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -34,7 +34,11 @@ function RegisterPage() {
       localStorage.setItem("user", JSON.stringify(response.data.user));
       navigate("/");
     } catch (err) {
-      setError(err.response?.data?.message || t('register_error'));
+      if (err.response?.data?.message === 'User already exists') {
+        alert(t('user_already_exists'));
+      } else {
+        setError(err.response?.data?.message || t('register_error'));
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- handle existing user signup with localized alert
- add `user_already_exists` to translations
- update lint script to use `eslint.config.cjs`
- extend socket sync test timeout

## Testing
- `npm run lint` *(fails: Missing node_modules)*
- `npm test` *(fails: Missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c75bd70832298135e8a25a8c0bd