### PR TITLE
Redirect GM users from character creation

### DIFF
--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -1,11 +1,9 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { createCharacter, getRaces, getProfessions } from '../utils/api';
-import api from '../api/axios';
-import { getRandomElement } from '../utils/characterUtils';
+import { createCharacter } from '../utils/api';
 
 
 import { useAppearance } from '../context/AppearanceContext';
@@ -17,6 +15,13 @@ const CharacterCreatePage = () => {
   const [gender, setGender] = useState('male');
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    const role = getStoredUserRole();
+    if (role === 'gm') {
+      navigate('/gm-dashboard');
+    }
+  }, [navigate]);
 
 
 


### PR DESCRIPTION
## Summary
- check stored user role on character create page
- redirect GM users straight to GM dashboard
- drop unused imports

## Testing
- `./setup.sh`
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d8f515dac8322a29fe35e577fdeea