### PR TITLE
Add character avatar generation

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -6,6 +6,7 @@ const Profession = require('../models/Profession');
 const generateStats = require('../utils/generateStats');
 const generateInventory = require('../utils/generateInventory');
 const generateAvatar = require('../utils/generateAvatar');
+const { generateCharacterImage } = require('../utils/ai');
 const slug = require('../utils/slugify');
 
 const allowedRaceCodes = new Set([
@@ -152,12 +153,20 @@ exports.create = async (req, res) => {
       console.warn(`Empty inventory for race ${raceCodeRaw} class ${classCodeLower}`);
     }
 
+    const avatarUrl = await generateCharacterImage(
+      raceCodeRaw,
+      classCodeLower,
+      finalGender,
+      inventory
+    );
+
 
   const newChar = new Character({
       user: req.user.id,
       name,
       description,
       image: avatar,
+      avatar: avatarUrl,
       gender: finalGender,
       race: race[0]?._id,
       profession: profession[0]?._id,

--- a/backend/src/models/Character.js
+++ b/backend/src/models/Character.js
@@ -24,6 +24,7 @@ const characterSchema = new mongoose.Schema({
     bonus: { type: Map, of: Number, default: {} }
   }],
   description: { type: String, default: '' },
+  avatar: { type: String, default: '' },
   image: { type: String, default: '' }, // посилання на файл/URL
 }, { timestamps: true });
 

--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -39,7 +39,7 @@ export default function CharacterCard({
     <>
       <div className="card max-w-[400px] flex flex-col items-center">
         <img
-          src={withApiHost(character.image) || '/default-avatar.png'}
+          src={withApiHost(character.avatar || character.image) || '/default-avatar.png'}
           alt={character.name}
           onError={(e) => (e.currentTarget.src = '/default-avatar.png')}
           className="w-full h-40 object-cover rounded mb-2"

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -43,7 +43,7 @@ export default function PlayerCard({ character, onSelect }) {
         className={`border rounded-lg shadow-lg p-4 bg-gradient-to-br from-gray-800 to-black text-white font-dnd w-56 ${borderColor}`}
       >
         <img
-          src={withApiHost(character.image) || '/default-avatar.png'}
+          src={withApiHost(character.avatar || character.image) || '/default-avatar.png'}
           alt="character"
           className="rounded mb-2 h-28 w-full object-cover"
           onError={e => (e.currentTarget.src = '/default-avatar.png')}


### PR DESCRIPTION
## Summary
- include `avatar` in `Character` model
- generate full character image during creation
- show avatar in CharacterCard and PlayerCard
- test avatar generation

## Testing
- `../setup.sh`
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685d8f4fe4a48322a144492d02c2f6e8