### PR TITLE
Update character image generator signature

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -156,8 +156,7 @@ exports.create = async (req, res) => {
     const avatarUrl = await generateCharacterImage(
       raceCodeRaw,
       classCodeLower,
-      finalGender,
-      inventory
+      finalGender
     );
 
 

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const { generateCharacterImage } = require('../utils/ai');
 
 router.post('/avatar', async (req, res) => {
-  const { description } = req.body;
+  const { race = 'human', profession = 'warrior', gender = 'male' } = req.body;
   try {
-    const url = await generateCharacterImage(description || 'fantasy character');
+    const url = await generateCharacterImage(race, profession, gender);
     res.json({ url });
   } catch (err) {
     console.error(err);

--- a/backend/src/utils/ai.js
+++ b/backend/src/utils/ai.js
@@ -6,7 +6,8 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 
-exports.generateCharacterImage = async (description) => {
+exports.generateCharacterImage = async (race, profession, gender) => {
+  const prompt = `${gender} ${race} ${profession}`;
   // If no API key is provided, fall back to preset avatars bundled in the repo
   if (!process.env.OPENAI_API_KEY) {
     try {
@@ -27,7 +28,7 @@ exports.generateCharacterImage = async (description) => {
       'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ prompt: description, n: 1, size: '512x512' }),
+    body: JSON.stringify({ prompt, n: 1, size: '512x512' }),
   });
   const data = await res.json();
   const url = data.data?.[0]?.url;

--- a/backend/src/utils/generateAvatar.js
+++ b/backend/src/utils/generateAvatar.js
@@ -26,7 +26,7 @@ async function generateAvatar(gender, raceCode, classCode) {
     }
 
     if (process.env.OPENAI_API_KEY) {
-      return await ai.generateCharacterImage(`${gender} ${raceCode} ${classCode}`);
+      return await ai.generateCharacterImage(raceCode, classCode, gender);
     }
 
     const files = fs.readdirSync(avatarsDir).filter(f => !f.startsWith('.'));

--- a/backend/tests/ai.test.js
+++ b/backend/tests/ai.test.js
@@ -14,7 +14,7 @@ app.use('/api/ai', aiRouter);
 describe('AI Routes', () => {
   describe('POST /api/ai/avatar', () => {
     it('should return generated image url', async () => {
-      const res = await request(app).post('/api/ai/avatar').send({ description: 'hero' });
+      const res = await request(app).post('/api/ai/avatar').send({ race: 'elf', profession: 'wizard', gender: 'male' });
       expect(res.statusCode).toBe(200);
       expect(res.body.url).toBe('http://image.test/avatar.png');
     });

--- a/backend/tests/ai.util.test.js
+++ b/backend/tests/ai.util.test.js
@@ -10,7 +10,7 @@ describe('generateCharacterImage fallback', () => {
   it('returns random avatar path', async () => {
     jest.spyOn(fs, 'readdirSync').mockReturnValue(['a.png', 'b.png']);
 
-    const path = await generateCharacterImage('desc');
+    const path = await generateCharacterImage('elf', 'wizard', 'male');
 
     expect(path.startsWith('/avatars/')).toBe(true);
   });
@@ -18,7 +18,7 @@ describe('generateCharacterImage fallback', () => {
   it('returns empty string when no files', async () => {
     jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 
-    const path = await generateCharacterImage('desc');
+    const path = await generateCharacterImage('elf', 'wizard', 'male');
 
     expect(path).toBe('');
   });

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -163,7 +163,7 @@ describe('Character Controller - create', () => {
 
     await characterController.create(req, res);
 
-    expect(generateCharacterImage).toHaveBeenCalledWith('forest_elf', 'wizard', 'male', inv);
+    expect(generateCharacterImage).toHaveBeenCalledWith('forest_elf', 'wizard', 'male');
     expect(saved.avatar).toBe('/images/generated.png');
   });
 


### PR DESCRIPTION
## Summary
- generate character images using explicit parameters rather than a description
- adapt avatar generation and character creation to the new AI util API
- expose the new API through `/api/ai/avatar`
- update related unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d92994ddc8322b21910eb89c5e0e2