### PR TITLE
Add archer and healer classes

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -63,7 +63,9 @@ async function seed() {
     { code: 'wizard', name: 'Маг', modifiers: { health: 0, defense: 0, strength: 0, intellect: 2, agility: 0, charisma: 0, mp: 1 } },
     { code: 'assassin', name: 'Асасін', modifiers: { health: 0, defense: 0, strength: 1, intellect: 0, agility: 1, charisma: 0, mp: 0 } },
     { code: 'paladin', name: 'Паладин', modifiers: { health: 1, defense: 0, strength: 1, intellect: 0, agility: 0, charisma: 1, mp: 0 } },
-    { code: 'bard', name: 'Бард', modifiers: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 1, mp: 0 } }
+    { code: 'bard', name: 'Бард', modifiers: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 1, mp: 0 } },
+    { code: 'archer', name: 'Лучник', modifiers: { health: 0, defense: 0, strength: 1, intellect: 0, agility: 2, charisma: 0, mp: 0 } },
+    { code: 'healer', name: 'Цілитель', modifiers: { health: 0, defense: 0, strength: 0, intellect: 1, agility: 0, charisma: 1, mp: 1 } }
 
   ];
   const characteristics = [
@@ -139,6 +141,32 @@ async function seed() {
       ],
       misc: [
         { item: 'Святий амулет' }
+      ]
+    },
+    archer: {
+      weapon: [
+        { item: 'Довгий лук', bonus: { agility: 2 } },
+        { item: 'Арбалет', bonus: { agility: 1 } }
+      ],
+      armor: [
+        { item: 'Шкіряна броня', bonus: { agility: 1 } },
+        { item: 'Капюшон мисливця' }
+      ],
+      misc: [
+        { item: 'Колчан стріл' }
+      ]
+    },
+    healer: {
+      weapon: [
+        { item: 'Жезл зцілення', bonus: { intellect: 1 } },
+        { item: 'Святий символ', bonus: { mp: 1 } }
+      ],
+      armor: [
+        { item: 'Ряса', bonus: { health: 1 } },
+        { item: 'Талісман віри', bonus: { charisma: 1 } }
+      ],
+      misc: [
+        { item: 'Зілля лікування' }
       ]
     }
   };

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -22,7 +22,9 @@ const allowedClassCodes = new Set([
   'wizard',
   'assassin',
   'paladin',
-  'bard'
+  'bard',
+  'archer',
+  'healer'
 ]);
 const professionAliases = { mage: 'wizard' };
 

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -28,7 +28,7 @@ describe('seed script', () => {
     const races = [
       'human','forest_elf','dark_elf','gnome','dwarf','orc'
     ];
-    const classes = ['warrior','mage','assassin','paladin','bard'];
+    const classes = ['warrior','mage','assassin','paladin','bard','archer','healer'];
     for (const r of races) {
       for (const c of classes) {
         const count = await StartingSet.countDocuments({ raceCode: r, classCode: c });

--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -6,6 +6,7 @@ export function getClassBorderColor(profession) {
     paladin: 'border-yellow-600',
     bard: 'border-purple-600',
     healer: 'border-teal-600',
+    wizard: 'border-indigo-600',
     assassin: 'border-gray-600',
   };
   const key = (profession || '').toLowerCase();


### PR DESCRIPTION
## Summary
- permit `archer` and `healer` in character creation
- seed new professions and inventories
- color mapping includes wizard
- update test expectations for seed script

## Testing
- `./setup.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d97ebde808322be61921b0bc92a99