### PR TITLE
Refactor stat and inventory generation

### DIFF
--- a/backend/src/data/classRaceBonuses.js
+++ b/backend/src/data/classRaceBonuses.js
@@ -1,0 +1,18 @@
+const raceBonuses = {
+  human: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 0, mp: 0 },
+  forest_elf: { health: 0, defense: 0, strength: 0, intellect: 1, agility: 2, charisma: 0, mp: 0 },
+  dark_elf: { health: 0, defense: 0, strength: 0, intellect: 1, agility: 1, charisma: 0, mp: 0 },
+  gnome: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 0, mp: 0 },
+  dwarf: { health: 1, defense: 1, strength: 0, intellect: 0, agility: 0, charisma: 0, mp: 0 },
+  orc: { health: 1, defense: 0, strength: 2, intellect: 0, agility: 0, charisma: 0, mp: 0 }
+};
+
+const classBonuses = {
+  warrior: { health: 0, defense: 1, strength: 2, intellect: 0, agility: 0, charisma: 0, mp: 0 },
+  wizard: { health: 0, defense: 0, strength: 0, intellect: 2, agility: 0, charisma: 0, mp: 1 },
+  assassin: { health: 0, defense: 0, strength: 1, intellect: 0, agility: 1, charisma: 0, mp: 0 },
+  paladin: { health: 1, defense: 0, strength: 1, intellect: 0, agility: 0, charisma: 1, mp: 0 },
+  bard: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 1, mp: 0 }
+};
+
+module.exports = { raceBonuses, classBonuses };

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,6 +1,98 @@
 
-const StartingSet = require('../models/StartingSet');
 const slug = require('./slugify');
+
+const classInventory = {
+  warrior: {
+    weapon: [
+      { item: 'Меч', bonus: { strength: 2 } },
+      { item: 'Сокира', bonus: { strength: 2 } }
+    ],
+    armor: [
+      { item: 'Щит', bonus: { defense: 1 } },
+      { item: 'Шкіряна броня', bonus: { agility: 1 } }
+    ],
+    misc: [
+      { item: 'Зілля здоров’я' }
+    ]
+  },
+  wizard: {
+    weapon: [
+      { item: 'Магічний посох', bonus: { intellect: 2 } },
+      { item: 'Чарівна паличка', bonus: { intellect: 1 } }
+    ],
+    armor: [
+      { item: 'Обруч мудрості', bonus: { intellect: 1 } },
+      { item: 'Тканинна мантія', bonus: { health: 1 } }
+    ],
+    misc: [
+      { item: 'Мана-зілля' },
+      { item: 'Книга заклять' }
+    ]
+  },
+  assassin: {
+    weapon: [
+      { item: 'Лук', bonus: { agility: 1 } },
+      { item: 'Арбалет', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Шкіряна броня', bonus: { agility: 1 } },
+      { item: 'Ніж для виживання' }
+    ],
+    misc: [
+      { item: 'Колчан стріл' }
+    ]
+  },
+  bard: {
+    weapon: [
+      { item: 'Лютня', bonus: { charisma: 1 } },
+      { item: 'Легкий меч', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Короткий лук', bonus: { agility: 1 } },
+      { item: 'Пісенник' }
+    ],
+    misc: []
+  },
+  paladin: {
+    weapon: [
+      { item: 'Молот', bonus: { strength: 1 } },
+      { item: 'Святий меч', bonus: { strength: 2 } }
+    ],
+    armor: [
+      { item: 'Латна броня', bonus: { health: 2 } },
+      { item: 'Святий щит', bonus: { charisma: 1 } }
+    ],
+    misc: [
+      { item: 'Святий амулет' }
+    ]
+  }
+};
+
+function combine(arrays) {
+  if (!arrays.length) return [[]];
+  const [first, ...rest] = arrays;
+  const combos = combine(rest);
+  const result = [];
+  for (const item of first) {
+    for (const c of combos) {
+      result.push([item, ...c]);
+    }
+  }
+  return result;
+}
+
+const races = ['human', 'forest_elf', 'dark_elf', 'gnome', 'dwarf', 'orc'];
+const startingSets = {};
+for (const race of races) {
+  startingSets[race] = {};
+}
+for (const [cls, groups] of Object.entries(classInventory)) {
+  const arrays = Object.values(groups).filter(a => a.length);
+  const combos = combine(arrays).slice(0, 3);
+  for (const race of races) {
+    startingSets[race][cls] = combos;
+  }
+}
 
 const raceInventory = {
   human: [{ item: 'Монета удачі', amount: 1, bonus: { charisma: 1 } }],
@@ -15,24 +107,23 @@ function randomItem(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-async function generateInventory(raceCode, classCode) {
+function generateInventory(raceCode, classCode) {
   const result = [];
 
-  const sets = await StartingSet.find({ classCode, raceCode }).populate('items');
+  const baseCode = raceCode.replace(/_(male|female)$/i, '');
+  const sets = startingSets[baseCode]?.[classCode] || [];
   if (sets.length) {
     const selected = randomItem(sets);
-    for (const item of selected.items) {
-      const bonuses = item.bonuses ? Object.fromEntries(item.bonuses) : {};
+    for (const item of selected) {
       result.push({
-        item: item.name,
-        code: item.code || slug(item.name),
-        amount: 1,
-        bonus: bonuses
+        item: item.item,
+        code: slug(item.item),
+        amount: item.amount ?? 1,
+        bonus: item.bonus || {}
       });
     }
   }
 
-  const baseCode = raceCode.replace(/_(male|female)$/i, '');
   const raceItems = raceInventory[baseCode] || [];
   for (const r of raceItems) {
     result.push({

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,56 +1,37 @@
-const StartingSet = require('../src/models/StartingSet');
-jest.mock('../src/models/StartingSet');
-
 const generateInventory = require('../src/utils/generateInventory');
 
 describe('generateInventory', () => {
-  const sets = [
-    { items: [ { name: 'Меч' }, { name: 'Щит' }, { name: 'Зілля здоров’я' } ] },
-    { items: [ { name: 'Меч' }, { name: 'Шкіряна броня' }, { name: 'Зілля здоров’я' } ] },
-    { items: [ { name: 'Сокира' }, { name: 'Щит' }, { name: 'Зілля здоров’я' } ] },
-    { items: [ { name: 'Сокира' }, { name: 'Шкіряна броня' }, { name: 'Зілля здоров’я' } ] },
-  ];
-
-  it('selects random items for each category', async () => {
-    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
-    const spy = StartingSet.find;
+  it('selects random items for each category', () => {
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
 
-    const items = await generateInventory('orc', 'warrior');
+    const items = generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    expect(spy).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc' });
-
     expect(items).toEqual([
-      { item: 'Меч', code: 'меч', amount: 1, bonus: {} },
-      { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: {} },
+      { item: 'Меч', code: 'меч', amount: 1, bonus: { strength: 2 } },
+      { item: 'Щит', code: 'щит', amount: 1, bonus: { defense: 1 } },
       { item: 'Зілля здоров’я', code: 'зілля_здоров’я', amount: 1, bonus: {} },
       { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
     ]);
   });
 
-  it('mixes items across sets', async () => {
-    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(sets) });
-    const spy2 = StartingSet.find;
+  it('mixes items across sets', () => {
     jest.spyOn(Math, 'random').mockReturnValueOnce(0.6);
 
-    const items = await generateInventory('orc', 'warrior');
+    const items = generateInventory('orc', 'warrior');
     Math.random.mockRestore();
 
-    expect(spy2).toHaveBeenCalledWith({ classCode: 'warrior', raceCode: 'orc' });
-
     expect(items).toEqual([
-      { item: 'Сокира', code: 'сокира', amount: 1, bonus: {} },
-      { item: 'Щит', code: 'щит', amount: 1, bonus: {} },
+      { item: 'Меч', code: 'меч', amount: 1, bonus: { strength: 2 } },
+      { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: { agility: 1 } },
       { item: 'Зілля здоров’я', code: 'зілля_здоров’я', amount: 1, bonus: {} },
       { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
     ]);
   });
 
-  it('returns empty array for unknown inputs and logs warning', async () => {
-    StartingSet.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+  it('returns empty array for unknown inputs and logs warning', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const items = await generateInventory('unknown', 'unknown');
+    const items = generateInventory('unknown', 'unknown');
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
     expect(items).toEqual([]);

--- a/backend/tests/generateStats.test.js
+++ b/backend/tests/generateStats.test.js
@@ -1,18 +1,9 @@
-const Race = require('../src/models/Race');
-const Profession = require('../src/models/Profession');
-
-jest.mock('../src/models/Race');
-jest.mock('../src/models/Profession');
-
 const generateStats = require('../src/utils/generateStats');
 
 describe('generateStats', () => {
-  it('applies race and class bonuses', async () => {
-    Race.findOne.mockResolvedValue({ modifiers: new Map([['strength', 2], ['health', 1]]) });
-    Profession.findOne.mockResolvedValue({ modifiers: new Map([['strength', 2], ['defense', 1]]) });
-
+  it('applies race and class bonuses', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0);
-    const stats = await generateStats('orc_male', 'warrior');
+    const stats = generateStats('orc_male', 'warrior');
     Math.random.mockRestore();
     expect(stats).toEqual({
       health: 6,


### PR DESCRIPTION
## Summary
- store static race and class bonuses in `classRaceBonuses.js`
- refactor `generateStats` to use static bonuses
- create static starting equipment sets and update inventory generation
- adjust tests for new helper data

## Testing
- `../setup.sh`
- `npm test`
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685d97eb9ec08322bea1f6b566c6db05