### PR TITLE
Add archer and healer class support

### DIFF
--- a/backend/src/data/classRaceBonuses.js
+++ b/backend/src/data/classRaceBonuses.js
@@ -12,7 +12,9 @@ const classBonuses = {
   wizard: { health: 0, defense: 0, strength: 0, intellect: 2, agility: 0, charisma: 0, mp: 1 },
   assassin: { health: 0, defense: 0, strength: 1, intellect: 0, agility: 1, charisma: 0, mp: 0 },
   paladin: { health: 1, defense: 0, strength: 1, intellect: 0, agility: 0, charisma: 1, mp: 0 },
-  bard: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 1, mp: 0 }
+  bard: { health: 0, defense: 0, strength: 0, intellect: 0, agility: 0, charisma: 1, mp: 0 },
+  archer: { health: 0, defense: 0, strength: 1, intellect: 0, agility: 2, charisma: 0, mp: 0 },
+  healer: { health: 0, defense: 0, strength: 0, intellect: 1, agility: 0, charisma: 1, mp: 1 }
 };
 
 module.exports = { raceBonuses, classBonuses };

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -65,6 +65,32 @@ const classInventory = {
     misc: [
       { item: 'Святий амулет' }
     ]
+  },
+  archer: {
+    weapon: [
+      { item: 'Довгий лук', bonus: { agility: 2 } },
+      { item: 'Арбалет', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Шкіряна броня', bonus: { agility: 1 } },
+      { item: 'Капюшон мисливця' }
+    ],
+    misc: [
+      { item: 'Колчан стріл' }
+    ]
+  },
+  healer: {
+    weapon: [
+      { item: 'Жезл зцілення', bonus: { intellect: 1 } },
+      { item: 'Святий символ', bonus: { mp: 1 } }
+    ],
+    armor: [
+      { item: 'Ряса', bonus: { health: 1 } },
+      { item: 'Талісман віри', bonus: { charisma: 1 } }
+    ],
+    misc: [
+      { item: 'Зілля лікування' }
+    ]
   }
 };
 

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -29,6 +29,34 @@ describe('generateInventory', () => {
     ]);
   });
 
+  it('generates inventory for archer', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
+
+    const items = generateInventory('orc', 'archer');
+    Math.random.mockRestore();
+
+    expect(items).toEqual([
+      { item: 'Довгий лук', code: 'довгий_лук', amount: 1, bonus: { agility: 2 } },
+      { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: { agility: 1 } },
+      { item: 'Колчан стріл', code: 'колчан_стріл', amount: 1, bonus: {} },
+      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+    ]);
+  });
+
+  it('generates inventory for healer', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.3);
+
+    const items = generateInventory('orc', 'healer');
+    Math.random.mockRestore();
+
+    expect(items).toEqual([
+      { item: 'Жезл зцілення', code: 'жезл_зцілення', amount: 1, bonus: { intellect: 1 } },
+      { item: 'Ряса', code: 'ряса', amount: 1, bonus: { health: 1 } },
+      { item: 'Зілля лікування', code: 'зілля_лікування', amount: 1, bonus: {} },
+      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+    ]);
+  });
+
   it('returns empty array for unknown inputs and logs warning', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const items = generateInventory('unknown', 'unknown');


### PR DESCRIPTION
## Summary
- include archer and healer class bonuses
- generate starter equipment for the new classes
- cover archer and healer inventory in tests

## Testing
- `./setup.sh`
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9c41d7b4832288ad1def1eb904bb