### PR TITLE
Implement full character stats display

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -8,6 +8,8 @@ import translateEffect from '../utils/effectUtils';
 
 export default function CharacterCard({
   character,
+  stats,
+  inventory,
   editLabel,
   onEdit,
   onDelete,
@@ -53,6 +55,67 @@ export default function CharacterCard({
         {character.description && (
           <p className="text-sm italic mb-2 text-center">{character.description}</p>
         )}
+        {(stats || character.stats) && (
+          <ul className="list-none pl-0 text-xs mb-1 space-y-0.5">
+            {Object.entries(stats || character.stats).map(([key, value]) => (
+              <li key={key}>
+                {translateOrRaw(t, `stats.${key.toLowerCase()}`, key)}: {value}
+              </li>
+            ))}
+          </ul>
+        )}
+        {(inventory || character.inventory) && (() => {
+          const inv = normalizeInventory(inventory || character.inventory);
+          if (inv.type === 'array' && inv.items.length > 0) {
+            return (
+              <ul className="list-disc pl-4 text-xs space-y-0.5 mb-1">
+                {inv.items.map((it, idx) => {
+                  const bonusData =
+                    it.bonus && typeof it.bonus === 'object' && Object.keys(it.bonus).length
+                      ? ' (' +
+                        Object.entries(it.bonus)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
+                          .join(', ') +
+                        ')'
+                      : '';
+                  return (
+                    <li key={idx}>
+                      {translateOrRaw(t, `item.${(it.code || it.item).toLowerCase()}`, it.item)}
+                      {it.amount > 1 ? ` x${it.amount}` : ''}
+                      {bonusData}
+                      {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          }
+          if (inv.type === 'object' && inv.items.length > 0) {
+            return (
+              <ul className="list-disc pl-4 text-xs space-y-0.5 mb-1">
+                {inv.items.map(([key, it]) => {
+                  const bonusData =
+                    it.bonus && typeof it.bonus === 'object' && Object.keys(it.bonus).length
+                      ? ' (' +
+                        Object.entries(it.bonus)
+                          .map(([k, v]) => `${v > 0 ? '+' : ''}${v} ${translateOrRaw(t, 'stats.' + k.toLowerCase(), k)}`)
+                          .join(', ') +
+                        ')'
+                      : '';
+                  return (
+                    <li key={key}>
+                      {translateOrRaw(t, `item.${(it.code || it.item).toLowerCase()}`, it.item)}
+                      {it.amount > 1 ? ` x${it.amount}` : ''}
+                      {bonusData}
+                      {it.effect ? ` (${translateEffect(it.effect, t)})` : ''}
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          }
+          return null;
+        })()}
         <div className="mt-auto flex flex-wrap justify-center gap-2">
           {onEdit && (
             <button
@@ -101,19 +164,19 @@ export default function CharacterCard({
             {t('save')}
           </button>
         )}
-        {character.stats && (
+        {(stats || character.stats) && (
           <ul className="list-none pl-0 text-sm mb-2 space-y-0.5">
-            {Object.entries(character.stats).map(([key, value]) => (
+            {Object.entries(stats || character.stats).map(([key, value]) => (
               <li key={key}>
                 {translateOrRaw(t, `stats.${key.toLowerCase()}`, key)}: {value}
               </li>
             ))}
           </ul>
         )}
-        <h4 className="text-dndgold mb-1">{t('inventory.title')}</h4>
+        <h4 className="text-dndgold mb-1">{t('inventory')}</h4>
         <ul className="list-disc pl-4 text-sm space-y-0.5">
           {(() => {
-            const inv = normalizeInventory(character.inventory);
+            const inv = normalizeInventory(inventory || character.inventory);
             if (inv.type === 'array' && inv.items.length > 0) {
               return inv.items.map((it, idx) => {
                 const bonusData =
@@ -164,7 +227,7 @@ export default function CharacterCard({
                 );
               });
             }
-            return <li>{t('inventory.empty')}</li>;
+            return <li>{t('inventory_ui.empty')}</li>;
           })()}
         </ul>
       </Modal>

--- a/frontend/src/components/InventoryEditor.jsx
+++ b/frontend/src/components/InventoryEditor.jsx
@@ -32,14 +32,14 @@ export default function InventoryEditor({ inventory, onChange }) {
     setItems(newItems);
     onChange(newItems);
     setInput('');
-    showToast(t('inventory.item_added'), 'success');
+    showToast(t('inventory_ui.item_added'), 'success');
   };
 
   const removeItem = (idx) => {
     const newItems = items.filter((_, i) => i !== idx);
     setItems(newItems);
     onChange(newItems);
-    showToast(t('inventory.item_removed'), 'success');
+    showToast(t('inventory_ui.item_removed'), 'success');
   };
 
   const handleDragEnd = (result) => {
@@ -49,7 +49,7 @@ export default function InventoryEditor({ inventory, onChange }) {
     newItems.splice(result.destination.index, 0, moved);
     setItems(newItems);
     onChange(newItems);
-    showToast(t('inventory.order_changed'), 'success');
+    showToast(t('inventory_ui.order_changed'), 'success');
   };
 
   return (
@@ -57,7 +57,7 @@ export default function InventoryEditor({ inventory, onChange }) {
       <div className="flex gap-2 mb-2">
         <input
           className="rounded-2xl px-3 py-1 bg-[#2c1a12] border border-dndgold text-dndgold flex-1"
-          placeholder={t('inventory.new_item')}
+          placeholder={t('inventory_ui.new_item')}
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
@@ -66,10 +66,10 @@ export default function InventoryEditor({ inventory, onChange }) {
           onChange={(e) => setType(e.target.value)}
           className="rounded-2xl px-2 bg-[#2c1a12] border border-dndgold text-dndgold"
         >
-          <option value="weapon">{t('inventory.types.weapon')}</option>
-          <option value="armor">{t('inventory.types.armor')}</option>
-          <option value="potion">{t('inventory.types.potion')}</option>
-          <option value="misc">{t('inventory.types.misc')}</option>
+          <option value="weapon">{t('inventory_ui.types.weapon')}</option>
+          <option value="armor">{t('inventory_ui.types.armor')}</option>
+          <option value="potion">{t('inventory_ui.types.potion')}</option>
+          <option value="misc">{t('inventory_ui.types.misc')}</option>
         </select>
         <button
           type="button"
@@ -87,10 +87,10 @@ export default function InventoryEditor({ inventory, onChange }) {
           className="rounded-2xl px-2 bg-[#2c1a12] border border-dndgold text-dndgold"
         >
           <option value="all">{t('all')}</option>
-          <option value="weapon">{t('inventory.types.weapon')}</option>
-          <option value="armor">{t('inventory.types.armor')}</option>
-          <option value="potion">{t('inventory.types.potion')}</option>
-          <option value="misc">{t('inventory.types.misc')}</option>
+          <option value="weapon">{t('inventory_ui.types.weapon')}</option>
+          <option value="armor">{t('inventory_ui.types.armor')}</option>
+          <option value="potion">{t('inventory_ui.types.potion')}</option>
+          <option value="misc">{t('inventory_ui.types.misc')}</option>
         </select>
       </div>
 
@@ -113,7 +113,7 @@ export default function InventoryEditor({ inventory, onChange }) {
                         className="flex items-center gap-2 mb-1"
                       >
                         <span>{item.item}</span>
-                        <span className="text-xs text-dndgold/60">({t(`inventory.types.${item.type}`)})</span>
+                        <span className="text-xs text-dndgold/60">({t(`inventory_ui.types.${item.type}`)})</span>
                         <button
                           type="button"
                           onClick={() => removeItem(i)}
@@ -128,7 +128,7 @@ export default function InventoryEditor({ inventory, onChange }) {
               )}
               {provided.placeholder}
               {items.filter((i) => (filter === 'all' ? true : i.type === filter)).length === 0 && (
-                <li className="text-dndgold/60">{t('inventory.empty')}</li>
+                <li className="text-dndgold/60">{t('inventory_ui.empty')}</li>
               )}
             </ul>
           )}

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -19,7 +19,7 @@ export default function InventoryList({ items, filter = 'all' }) {
 
   return (
     <div className="bg-[#20100a]/90 p-2 rounded-2xl mb-4 w-full max-w-xl mx-auto">
-      <div className="text-dndgold font-bold mb-1">{t('inventory.title')}</div>
+      <div className="text-dndgold font-bold mb-1">{t('inventory')}</div>
       <ul className="list-disc pl-5">
         {filtered.map((item, i) => (
           <li key={i} className="text-dndgold">

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -150,7 +150,7 @@ export default function PlayerCard({ character, onSelect }) {
           }
           return (
             <ul className="list-disc pl-4 mt-2 space-y-0.5">
-              <li>{t('inventory.empty')}</li>
+              <li>{t('inventory_ui.empty')}</li>
             </ul>
           );
         })()}

--- a/frontend/src/components/PlayerStatusTable.jsx
+++ b/frontend/src/components/PlayerStatusTable.jsx
@@ -40,7 +40,7 @@ export default function PlayerStatusTable({ players, isGM, onEdit, onKick }) {
           <th className="text-left">HP</th>
           <th className="text-left">MP</th>
           <th className="text-left">AC</th>
-          <th className="text-left">{t('stats_label')}</th>
+          <th className="text-left">{t('stats')}</th>
           {isGM && <th className="text-left">DMG</th>}
           {isGM && <th className="text-left">{t('actions')}</th>}
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -108,7 +108,7 @@
   "player": "Player",
   "race": "Race",
   "class": "Class",
-  "stats_label": "Stats",
+  "stats": "Stats",
   "edit": "Edit",
   "kick": "Kick",
   "delete": "Delete",
@@ -117,8 +117,8 @@
   "monster_name": "Monster Name",
   "generate_initiative": "Generate Initiative",
   "start_initiative": "Start Initiative",
-  "inventory": {
-    "title": "Inventory",
+  "inventory": "Inventory",
+  "inventory_ui": {
     "item_added": "Item added",
     "item_removed": "Item removed",
     "order_changed": "Order changed",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -108,7 +108,7 @@
   "player": "Гравець",
   "race": "Раса",
   "class": "Клас",
-  "stats_label": "Статистика",
+  "stats": "Статистика",
   "edit": "Редагувати",
   "kick": "Вигнати",
   "delete": "Видалити",
@@ -117,8 +117,8 @@
   "monster_name": "Ім'я монстра",
   "generate_initiative": "Згенерувати ініціативу",
   "start_initiative": "Почати ініціативу",
-  "inventory": {
-    "title": "Інвентар",
+  "inventory": "Інвентар",
+  "inventory_ui": {
     "item_added": "Предмет додано",
     "item_removed": "Предмет видалено",
     "order_changed": "Порядок змінено",

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -127,6 +127,8 @@ const ProfilePage = () => {
               <div key={char._id} className="flex flex-col items-center">
                 <CharacterCard
                   character={char}
+                  stats={char.stats}
+                  inventory={char.inventory}
                   editLabel={t('enter')}
                   onEdit={() => handleSelect(char._id)}
                   onDelete={() => handleDelete(char._id)}
@@ -148,7 +150,7 @@ const ProfilePage = () => {
                     ))}
                   </ul>
                 )}
-                <h4 className="text-xs mt-1">{t('inventory.title')}</h4>
+                <h4 className="text-xs mt-1">{t('inventory')}</h4>
                 <ul className="list-disc pl-4 text-xs space-y-0.5">
                   {(() => {
                     const inv = normalizeInventory(char.inventory);
@@ -198,7 +200,7 @@ const ProfilePage = () => {
                         );
                       });
                     }
-                    return <li>{t('inventory.empty')}</li>;
+                    return <li>{t('inventory_ui.empty')}</li>;
                   })()}
                 </ul>
               </div>

--- a/frontend/src/pages/gm/GMControlPage.jsx
+++ b/frontend/src/pages/gm/GMControlPage.jsx
@@ -181,7 +181,7 @@ function Control({ tableId }) {
 
       {players.some(p => p.character) && (
         <div>
-          <div className="font-bold mb-1">{t('inventory.title')}</div>
+          <div className="font-bold mb-1">{t('inventory')}</div>
           <select
             value={selectedChar || ''}
             onChange={e => setSelectedChar(e.target.value)}


### PR DESCRIPTION
## Summary
- show character stats & inventory on profile character cards
- rename translation key `stats_label` -> `stats`
- use new `inventory` translation label and move inventory strings to `inventory_ui`
- update components to use new translation keys

## Testing
- `npm test` *(fails: Missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d9e5cbabc8322a171aae6903f98d3