### PR TITLE
Add translation keys and replace strings

### DIFF
--- a/frontend/src/components/DiceBox.jsx
+++ b/frontend/src/components/DiceBox.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Dice5 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 export default function DiceBox({ className = '' }) {
   const [diceResult, setDiceResult] = useState(null);
   const [diceAnim, setDiceAnim] = useState(false);
+  const { t } = useTranslation();
 
   const rollDice = (type = 'd20') => {
     setDiceResult(null);
@@ -30,13 +32,13 @@ export default function DiceBox({ className = '' }) {
             className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
             onClick={() => rollDice('d20')}
           >
-            Кинути D20
+            {t('roll_d20')}
           </button>
           <button
             className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
             onClick={() => rollDice('d6')}
           >
-            Кинути D6
+            {t('roll_d6')}
           </button>
         </div>
         {diceAnim && (
@@ -51,7 +53,9 @@ export default function DiceBox({ className = '' }) {
           </motion.div>
         )}
         {diceResult && !diceAnim && (
-          <div className="text-xl text-dndgold font-bold mt-2">Результат: {diceResult}</div>
+          <div className="text-xl text-dndgold font-bold mt-2">
+            {t('result')}: {diceResult}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/DiceRoller.jsx
+++ b/frontend/src/components/DiceRoller.jsx
@@ -1,11 +1,13 @@
 import api from "../api/axios";
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
 
 export default function DiceRoller({ sessionId, isGM }) {
   const [rolling, setRolling] = useState(false);
   const [lastRoll, setLastRoll] = useState(null);
+  const { t } = useTranslation();
 
   const rollDice = async (diceType, isPrivate = false) => {
     setRolling(true);
@@ -40,11 +42,11 @@ export default function DiceRoller({ sessionId, isGM }) {
       </div>
       {lastRoll !== null && (
         <div className="text-dndgold text-lg font-dnd mt-1">
-          Результат: <b>{lastRoll}</b>
+          {t('result')}: <b>{lastRoll}</b>
         </div>
       )}
       <div className="text-xs text-dndgold/60 mt-2">
-        {isGM ? "Ваш кидок бачить лише майстер" : "Кидок бачать усі гравці"}
+        {isGM ? t('gm_roll_private') : t('roll_visible_all')}
       </div>
     </div>
   );

--- a/frontend/src/components/DiceRollerHidden.jsx
+++ b/frontend/src/components/DiceRollerHidden.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import api from "../api/axios";
+import { useTranslation } from 'react-i18next';
 
 const diceTypes = ["d20", "d12", "d10", "d8", "d6", "d4"];
 
 export default function DiceRollerHidden({ sessionId }) {
   const [rolling, setRolling] = useState(false);
   const [lastRoll, setLastRoll] = useState(null);
+  const { t } = useTranslation();
 
   const rollDice = async (type) => {
     setRolling(true);
@@ -39,11 +41,11 @@ export default function DiceRollerHidden({ sessionId }) {
       </div>
       {lastRoll !== null && (
         <div className="text-dndgold text-lg font-dnd mt-1">
-          Результат: <b>{lastRoll}</b>
+          {t('result')}: <b>{lastRoll}</b>
         </div>
       )}
       <div className="text-xs text-dndgold/60 mt-2">
-        Кидок бачить лише майстер
+        {t('gm_roll_private')}
       </div>
     </div>
   );

--- a/frontend/src/components/MapViewer.jsx
+++ b/frontend/src/components/MapViewer.jsx
@@ -1,11 +1,14 @@
 
+import { useTranslation } from 'react-i18next';
+
 export default function MapViewer({ mapUrl, name }) {
+  const { t } = useTranslation();
   return (
     <div className="w-full h-full flex flex-col items-center justify-center">
       {mapUrl ? (
         <img src={mapUrl} alt={name || "Map"} className="max-h-[55vh] max-w-full rounded-2xl shadow-dnd object-contain" />
       ) : (
-        <div className="text-dndgold/80 font-dnd text-xl">Карта не вибрана</div>
+        <div className="text-dndgold/80 font-dnd text-xl">{t('map_not_selected')}</div>
       )}
       {name && <div className="text-dndgold/70 mt-2">{name}</div>}
     </div>

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -58,14 +58,14 @@ export default function PlayerCard({ character, onSelect }) {
           onClick={() => setOpen(true)}
           className="mt-2 bg-dndgold text-dndred font-dnd rounded-2xl px-3 py-1"
         >
-          Детальніше
+          {t('more_details')}
         </button>
         {onSelect && (
           <button
             onClick={() => onSelect(character)}
             className="mt-2 bg-red-800 px-3 py-1 text-sm rounded text-white hover:bg-red-700"
           >
-            Грати
+            {t('play_character')}
           </button>
         )}
       </motion.div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -132,6 +132,14 @@
     "empty": "No items"
   },
   "random": "Random",
-  "all": "All"
+  "all": "All",
+  "roll_d20": "Roll D20",
+  "roll_d6": "Roll D6",
+  "result": "Result",
+  "more_details": "Details",
+  "play_character": "Play",
+  "map_not_selected": "Map not selected",
+  "gm_roll_private": "Only the Game Master can see your roll",
+  "roll_visible_all": "All players can see the roll"
 
 }

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -132,6 +132,14 @@
     "empty": "Порожньо"
   },
   "random": "Випадково",
-  "all": "Усі"
+  "all": "Усі",
+  "roll_d20": "Кинути D20",
+  "roll_d6": "Кинути D6",
+  "result": "Результат",
+  "more_details": "Детальніше",
+  "play_character": "Грати",
+  "map_not_selected": "Карта не вибрана",
+  "gm_roll_private": "Кидок бачить лише майстер",
+  "roll_visible_all": "Кидок бачать усі гравці"
 
 }


### PR DESCRIPTION
## Summary
- add Ukrainian and English translations for dice and map viewer texts
- replace hardcoded strings in dice components, player cards, and map viewer
- show dice roll visibility messages through i18n

## Testing
- `./setup.sh`
- `cd frontend && npm test`
- `cd ../backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dbc670f2083229e7b6b963d3cfccc