### PR TITLE
Update GM control route and param

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ are redirected to `/characters` where they can manage their heroes. Users with t
 
 - `/gm-dashboard` – overview for game masters
 - `/gm-table/:tableId` – run a specific table
-- `/gm-control/:id` – manage player controls
+- `/gm-control/:tableId` – manage player controls
 
 These routes are protected in the frontend using `PrivateRoute`, which now checks
 the stored user role.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -75,7 +75,7 @@ const App = () => {
 
     <Route path="/gm-dashboard" element={<PrivateRoute roles={['gm']}><GMDashboard /></PrivateRoute>} />
     <Route path="/gm-table/:tableId" element={<PrivateRoute roles={['gm']}><GameTablePage /></PrivateRoute>} />
-    <Route path="/gm-control/:id" element={<PrivateRoute roles={['gm']}><GMControlPage /></PrivateRoute>} />
+    <Route path="/gm-control/:tableId" element={<PrivateRoute roles={['gm']}><GMControlPage /></PrivateRoute>} />
 
     <Route path="*" element={<NotFoundPage />} />
   </Routes>

--- a/frontend/src/pages/gm/GMControlPage.jsx
+++ b/frontend/src/pages/gm/GMControlPage.jsx
@@ -26,8 +26,8 @@ function Control({ tableId }) {
   const [message, setMessage] = useState('');
   const { t } = useTranslation();
 
-  const params = useParams();
-  const id = tableId || params.tableId || params.id;
+  const { tableId: routeTableId } = useParams();
+  const currentTableId = tableId || routeTableId;
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -56,7 +56,7 @@ function Control({ tableId }) {
       socket.off('inventory-update', onInv);
       socket.off('inventory-update-all', onInvAll);
     };
-  }, [id, selectedChar]);
+  }, [currentTableId, selectedChar]);
 
   useEffect(() => {
     if (players.length && !selectedChar) {
@@ -80,7 +80,7 @@ function Control({ tableId }) {
   }, [selectedChar]);
 
   const kickPlayer = (uid) => {
-    socket.emit('kick-player', { tableId: id, userId: uid });
+    socket.emit('kick-player', { tableId: currentTableId, userId: uid });
   };
 
   const editPlayer = (p) => {
@@ -122,7 +122,7 @@ function Control({ tableId }) {
   const updateInventory = async (items) => {
     setInventory(items);
     socket.emit('inventory-update', {
-      tableId: id,
+      tableId: currentTableId,
       characterId: selectedChar,
       inventory: items,
     });
@@ -138,7 +138,7 @@ function Control({ tableId }) {
 
   const sendMessage = () => {
     if (!message.trim()) return;
-    socket.emit('gm-message', { tableId: id, targetUserId: target, text: message });
+    socket.emit('gm-message', { tableId: currentTableId, targetUserId: target, text: message });
     setMessage('');
 
   };
@@ -224,18 +224,18 @@ function Control({ tableId }) {
 
       </div>
       <DiceBox />
-      <DiceRollerHidden sessionId={id} />
+      <DiceRollerHidden sessionId={currentTableId} />
     </div>
   );
 }
 
 export default function GMControlPage() {
-  const { id } = useParams();
+  const { tableId } = useParams();
   const { user } = useUserStore();
   return (
-    <GameStateProvider tableId={id} user={user}>
+    <GameStateProvider tableId={tableId} user={user}>
       <div className="min-h-screen bg-dndbg text-dndgold font-dnd flex justify-center items-start pt-4">
-        <Control tableId={id} />
+        <Control tableId={tableId} />
       </div>
     </GameStateProvider>
   );


### PR DESCRIPTION
## Summary
- adjust route and README for `/gm-control/:tableId`
- update GMControlPage to rely on `tableId` param

## Testing
- `./setup.sh`
- `npm --prefix backend run lint`
- `npm --prefix frontend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685dbc68388c8322a4c808fb43978115