### PR TITLE
Fix duplicate t declarations in DiceBox

### DIFF
--- a/frontend/src/components/DiceBox.jsx
+++ b/frontend/src/components/DiceBox.jsx
@@ -1,50 +1,47 @@
-import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { motion } from 'framer-motion';
-import { Dice5 } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { motion } from "framer-motion";
+import { Dice5 } from "lucide-react";
 
-export default function DiceBox({ className = '' }) {
+export default function DiceBox({ className = "" }) {
   const [diceResult, setDiceResult] = useState(null);
   const { t } = useTranslation();
   const [diceAnim, setDiceAnim] = useState(false);
-  const { t } = useTranslation();
 
-  const rollDice = (type = 'd20') => {
+  const rollDice = (type = "d20") => {
     setDiceResult(null);
     setDiceAnim(true);
 
-    const audio = new Audio('/dice.mp3');
+    const audio = new Audio("/dice.mp3");
     audio.play().catch(() => {});
 
     setTimeout(() => {
-      const res = type === 'd20'
-        ? Math.ceil(Math.random() * 20)
-        : Math.ceil(Math.random() * 6);
+      const res =
+        type === "d20"
+          ? Math.ceil(Math.random() * 20)
+          : Math.ceil(Math.random() * 6);
       setDiceResult(res);
       setDiceAnim(false);
     }, 800);
   };
 
   return (
-    <div className={`border border-dndgold rounded-2xl p-2 bg-[#25160f]/80 ${className}`}>
+    <div
+      className={`border border-dndgold rounded-2xl p-2 bg-[#25160f]/80 ${className}`}
+    >
       <div className="flex flex-col items-center">
         <div className="flex gap-2">
           <button
             className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
-            onClick={() => rollDice('d20')}
+            onClick={() => rollDice("d20")}
           >
-
-            {t('roll_dice')} D20
-
+            {t("roll_dice")} D20
           </button>
           <button
             className="bg-dndred hover:bg-dndgold text-white hover:text-dndred font-dnd rounded-2xl px-4 py-2 transition-all"
-            onClick={() => rollDice('d6')}
+            onClick={() => rollDice("d6")}
           >
-
-            {t('roll_dice')} D6
-
+            {t("roll_dice")} D6
           </button>
         </div>
         {diceAnim && (
@@ -60,8 +57,9 @@ export default function DiceBox({ className = '' }) {
         )}
 
         {diceResult && !diceAnim && (
-          <div className="text-xl text-dndgold font-bold mt-2">{t('result')}: {diceResult}</div>
-
+          <div className="text-xl text-dndgold font-bold mt-2">
+            {t("result")}: {diceResult}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove duplicate `useTranslation` import and constant
- run `prettier`

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685dc0ce39448322924283519997157c