### PR TITLE
Fix character creation flow and environment examples

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 MONGO_URI=mongodb://localhost:27017/ddua
 JWT_SECRET=your_jwt_secret
 PORT=5000
-CLIENT_URL=http://localhost:5173
+CLIENT_URL=https://d-dua-1.onrender.com
 OPENAI_API_KEY=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:5000/api
-VITE_SOCKET_URL=http://localhost:5000
+VITE_API_URL=https://d-dua-1.onrender.com/api
+VITE_SOCKET_URL=https://d-dua-1.onrender.com

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -41,6 +41,7 @@
   "loading": "Loading...",
   "error_load_character": "Failed to load character",
   "error_save_changes": "Failed to save changes",
+  "error_create_character": "Failed to create character",
   "edit_inventory": "Edit Inventory",
   "admin_music": "Admin: Music",
   "track_name": "Track name",

--- a/frontend/src/locales/ua.json
+++ b/frontend/src/locales/ua.json
@@ -41,6 +41,7 @@
   "loading": "Завантаження...",
   "error_load_character": "Не вдалося завантажити персонажа",
   "error_save_changes": "Не вдалося зберегти зміни",
+  "error_create_character": "Не вдалося створити персонажа",
   "edit_inventory": "Редагування інвентарю",
   "admin_music": "Адмін: Музика",
   "track_name": "Назва треку",

--- a/frontend/src/pages/CharacterCreatePage.jsx
+++ b/frontend/src/pages/CharacterCreatePage.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { createCharacter } from '../utils/api';
+import { useToast } from '../context/ToastContext';
 
 
 import { useAppearance } from '../context/AppearanceContext';
@@ -25,15 +26,24 @@ const CharacterCreatePage = () => {
 
 
 
+  const { showToast } = useToast();
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    const newChar = await createCharacter({
-      name,
-      gender,
-    });
-    if (newChar && newChar._id) {
-      navigate('/characters');
+    try {
+      const newChar = await createCharacter({ name, gender });
+      if (newChar && newChar._id) {
+        navigate('/characters');
+      } else {
+        const msg = t('error_create_character');
+        if (showToast) showToast(msg, 'error');
+        else alert(msg);
+      }
+    } catch (err) {
+      console.error('Character creation failed', err);
+      const msg = t('error_create_character');
+      if (showToast) showToast(msg, 'error');
+      else alert(msg);
     }
   };
 


### PR DESCRIPTION
## Summary
- add error handling to CharacterCreatePage
- update env examples for deployment
- add translation key for failed character creation

## Testing
- `./setup.sh`
- `cd frontend && npm run lint && npm test`
- `cd ../backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685eac457dc88322bdb6cc07e572dbbf