### PR TITLE
Update character controller logging and errors

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -57,6 +57,7 @@ exports.getAllByUser = async (req, res) => {
 // Створити персонажа
 exports.create = async (req, res) => {
   try {
+    console.log('create payload:', req.body);
 
 
     let { name, description, image, gender, raceId, professionId, race: raceCode, profession: professionCode, class: classCode } = req.body;
@@ -70,15 +71,15 @@ exports.create = async (req, res) => {
 
 
     if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 50) {
-      return res.status(400).json({ message: 'Invalid name' });
+      return res.status(400).json({ error: 'Invalid name' });
     }
 
     if (description && (typeof description !== 'string' || description.length > 500)) {
-      return res.status(400).json({ message: 'Invalid description' });
+      return res.status(400).json({ error: 'Invalid description' });
     }
 
     if (image && (typeof image !== 'string' || image.length > 500)) {
-      return res.status(400).json({ message: 'Invalid image' });
+      return res.status(400).json({ error: 'Invalid image' });
     }
 
     name = name.trim();
@@ -121,17 +122,17 @@ exports.create = async (req, res) => {
 
   if (!race.length || !profession.length) {
     return res.status(400).json({
-      message: 'Missing races or professions to create character'
+      error: 'Missing races or professions to create character'
     });
   }
 
   const raceCodeValue = (race[0].code || '').toLowerCase();
   const profCodeValue = (profession[0].code || '').toLowerCase();
   if (!allowedRaceCodes.has(raceCodeValue)) {
-    return res.status(400).json({ message: 'Invalid race' });
+    return res.status(400).json({ error: 'Invalid race' });
   }
   if (!allowedClassCodes.has(profCodeValue)) {
-    return res.status(400).json({ message: 'Invalid class' });
+    return res.status(400).json({ error: 'Invalid class' });
   }
 
 

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -181,7 +181,7 @@ describe('Character Controller - create', () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({
-      message: 'Missing races or professions to create character'
+      error: 'Missing races or professions to create character'
     });
   });
 
@@ -244,7 +244,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid name' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid name' });
     expect(Race.aggregate).not.toHaveBeenCalled();
   });
 
@@ -256,7 +256,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid description' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid description' });
   });
 
   it('returns 400 when image is invalid', async () => {
@@ -266,7 +266,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid image' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid image' });
   });
 
   it('uses provided raceId and professionId', async () => {
@@ -358,7 +358,7 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid race' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid race' });
   });
 
   it('returns 400 for invalid class code', async () => {
@@ -372,6 +372,6 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid class' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid class' });
   });
 });


### PR DESCRIPTION
## Summary
- log request payload when creating characters
- use `error` field in 400 responses from character controller
- update tests for new error messages

## Testing
- `./setup.sh`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685eb80c0eec832292b800c1354efb30