### PR TITLE
Add slug support in admin race/profession pages

### DIFF
--- a/frontend/src/pages/admin/AdminProfessionsPage.jsx
+++ b/frontend/src/pages/admin/AdminProfessionsPage.jsx
@@ -5,10 +5,12 @@ import { useTranslation } from 'react-i18next';
 export default function AdminProfessionsPage() {
   const [professions, setProfessions] = useState([]);
   const [name, setName] = useState('');
+  const [code, setCode] = useState('');
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
   const [editingId, setEditingId] = useState(null);
   const [editName, setEditName] = useState('');
+  const [editCode, setEditCode] = useState('');
   const [editDescription, setEditDescription] = useState('');
   const { t } = useTranslation();
 
@@ -22,8 +24,8 @@ export default function AdminProfessionsPage() {
 
   const addProfession = async (e) => {
     e.preventDefault();
-    await api.post('/profession', { name, description });
-    setName(''); setDescription(''); fetchProfessions();
+    await api.post('/profession', { name, code, description });
+    setName(''); setCode(''); setDescription(''); fetchProfessions();
   };
 
   const removeProfession = async (id) => {
@@ -39,17 +41,19 @@ export default function AdminProfessionsPage() {
   const startEdit = (prof) => {
     setEditingId(prof._id);
     setEditName(prof.name);
+    setEditCode(prof.code);
     setEditDescription(prof.description || '');
   };
 
   const cancelEdit = () => {
     setEditingId(null);
     setEditName('');
+    setEditCode('');
     setEditDescription('');
   };
 
   const saveEdit = async (id) => {
-    await saveProfession(id, { name: editName, description: editDescription });
+    await saveProfession(id, { name: editName, code: editCode, description: editDescription });
     cancelEdit();
   };
 
@@ -63,6 +67,13 @@ export default function AdminProfessionsPage() {
             placeholder="Назва професії"
             value={name}
             onChange={e => setName(e.target.value)}
+            required
+          />
+          <input
+            className="rounded-2xl px-3 py-2 bg-[#2c1a12] border border-dndgold text-dndgold flex-1"
+            placeholder="Код"
+            value={code}
+            onChange={e => setCode(e.target.value)}
             required
           />
           <input
@@ -81,6 +92,7 @@ export default function AdminProfessionsPage() {
               <thead>
                 <tr className="text-left">
                   <th className="py-2">Назва</th>
+                  <th className="py-2">Код</th>
                   <th className="py-2">Опис</th>
                   <th className="py-2 w-24">Дії</th>
                 </tr>
@@ -97,6 +109,17 @@ export default function AdminProfessionsPage() {
                         />
                       ) : (
                         <span>{p.name}</span>
+                      )}
+                    </td>
+                    <td className="py-1 pr-2">
+                      {editingId === p._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editCode}
+                          onChange={e => setEditCode(e.target.value)}
+                        />
+                      ) : (
+                        <span>{p.code}</span>
                       )}
                     </td>
                     <td className="py-1 pr-2">

--- a/frontend/src/pages/admin/AdminRacesPage.jsx
+++ b/frontend/src/pages/admin/AdminRacesPage.jsx
@@ -5,10 +5,12 @@ import { useTranslation } from 'react-i18next';
 export default function AdminRacesPage() {
   const [races, setRaces] = useState([]);
   const [name, setName] = useState('');
+  const [code, setCode] = useState('');
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
   const [editingId, setEditingId] = useState(null);
   const [editName, setEditName] = useState('');
+  const [editCode, setEditCode] = useState('');
   const [editDescription, setEditDescription] = useState('');
   const { t } = useTranslation();
 
@@ -22,8 +24,8 @@ export default function AdminRacesPage() {
 
   const addRace = async (e) => {
     e.preventDefault();
-    await api.post('/race', { name, description });
-    setName(''); setDescription(''); fetchRaces();
+    await api.post('/race', { name, code, description });
+    setName(''); setCode(''); setDescription(''); fetchRaces();
   };
 
   const removeRace = async (id) => {
@@ -39,17 +41,19 @@ export default function AdminRacesPage() {
   const startEdit = (race) => {
     setEditingId(race._id);
     setEditName(race.name);
+    setEditCode(race.code);
     setEditDescription(race.description || '');
   };
 
   const cancelEdit = () => {
     setEditingId(null);
     setEditName('');
+    setEditCode('');
     setEditDescription('');
   };
 
   const saveEdit = async (id) => {
-    await saveRace(id, { name: editName, description: editDescription });
+    await saveRace(id, { name: editName, code: editCode, description: editDescription });
     cancelEdit();
   };
 
@@ -68,6 +72,13 @@ export default function AdminRacesPage() {
           />
           <input
             className="rounded-2xl px-3 py-2 bg-[#2c1a12] border border-dndgold text-dndgold flex-1"
+            placeholder="Код"
+            value={code}
+            onChange={e => setCode(e.target.value)}
+            required
+          />
+          <input
+            className="rounded-2xl px-3 py-2 bg-[#2c1a12] border border-dndgold text-dndgold flex-1"
             placeholder="Опис (необов'язково)"
             value={description}
             onChange={e => setDescription(e.target.value)}
@@ -82,6 +93,7 @@ export default function AdminRacesPage() {
               <thead>
                 <tr className="text-left">
                   <th className="py-2">Назва</th>
+                  <th className="py-2">Код</th>
                   <th className="py-2">Опис</th>
                   <th className="py-2 w-24">Дії</th>
                 </tr>
@@ -98,6 +110,17 @@ export default function AdminRacesPage() {
                         />
                       ) : (
                         <span>{race.name}</span>
+                      )}
+                    </td>
+                    <td className="py-1 pr-2">
+                      {editingId === race._id ? (
+                        <input
+                          className="w-full rounded-lg px-2 py-1 bg-[#2c1a12] border border-dndgold text-dndgold"
+                          value={editCode}
+                          onChange={e => setEditCode(e.target.value)}
+                        />
+                      ) : (
+                        <span>{race.code}</span>
                       )}
                     </td>
                     <td className="py-1 pr-2">


### PR DESCRIPTION
## Summary
- include race `code` slug when creating/editing races
- include profession `code` slug when creating/editing professions
- display the new fields in admin tables

## Testing
- `npm --prefix backend run lint`
- `npm --prefix frontend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685ebc0378208322a0f08bfc90cb3c12