### PR TITLE
Add slugify code for races and professions

### DIFF
--- a/backend/src/controllers/raceController.js
+++ b/backend/src/controllers/raceController.js
@@ -1,4 +1,5 @@
 const Race = require('../models/Race');
+const slug = require('../utils/slugify');
 
 exports.getAll = async (req, res) => {
   try {
@@ -11,7 +12,16 @@ exports.getAll = async (req, res) => {
 
 exports.create = async (req, res) => {
   try {
-    const { name, code, description, modifiers } = req.body;
+    let { name, code, description, modifiers } = req.body;
+    code = code || slug(name);
+
+    const existing = await Race.findOne({
+      $or: [{ name }, { code }]
+    });
+    if (existing) {
+      return res.status(400).json({ message: 'Race already exists' });
+    }
+
     const race = new Race({ name, code, description, modifiers });
     await race.save();
     res.status(201).json(race);
@@ -22,7 +32,17 @@ exports.create = async (req, res) => {
 
 exports.update = async (req, res) => {
   try {
-    const { name, code, description, modifiers } = req.body;
+    let { name, code, description, modifiers } = req.body;
+    code = code || slug(name);
+
+    const duplicate = await Race.findOne({
+      $or: [{ name }, { code }],
+      _id: { $ne: req.params.id }
+    });
+    if (duplicate) {
+      return res.status(400).json({ message: 'Race already exists' });
+    }
+
     const race = await Race.findByIdAndUpdate(
       req.params.id,
       { $set: { name, code, description, modifiers } },

--- a/backend/tests/professionController.test.js
+++ b/backend/tests/professionController.test.js
@@ -15,6 +15,7 @@ describe('Profession Controller', () => {
         instance = { save: jest.fn().mockResolvedValue(data) };
         return instance;
       });
+      Profession.findOne.mockResolvedValue(null);
 
       const req = { body: { name: 'Wizard', code: 'wizard', description: '', modifiers: { intellect: 1 } } };
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -27,10 +28,42 @@ describe('Profession Controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith(instance);
     });
+
+    it('derives code from name when missing', async () => {
+      let instance;
+      Profession.mockImplementation(data => {
+        instance = { save: jest.fn().mockResolvedValue(data) };
+        return instance;
+      });
+      Profession.findOne.mockResolvedValue(null);
+
+      const req = { body: { name: 'High Wizard', description: '', modifiers: {} } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await professionController.create(req, res);
+
+      expect(Profession).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'high_wizard' })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 400 when profession already exists', async () => {
+      Profession.findOne.mockResolvedValue({ _id: 'p2' });
+
+      const req = { body: { name: 'Wizard', code: 'wizard' } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await professionController.create(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Profession already exists' });
+    });
   });
 
   describe('update', () => {
     it('updates modifiers field', async () => {
+      Profession.findOne.mockResolvedValue(null);
       Profession.findByIdAndUpdate.mockResolvedValue({ _id: 'p1', modifiers: { intellect: 2 } });
 
       const req = { params: { id: 'p1' }, body: { name: 'Wizard', code: 'wizard', description: '', modifiers: { intellect: 2 } } };
@@ -44,6 +77,34 @@ describe('Profession Controller', () => {
         { new: true }
       );
       expect(res.json).toHaveBeenCalledWith({ _id: 'p1', modifiers: { intellect: 2 } });
+    });
+
+    it('derives code from name when missing', async () => {
+      Profession.findOne.mockResolvedValue(null);
+      Profession.findByIdAndUpdate.mockResolvedValue({ _id: 'p1' });
+
+      const req = { params: { id: 'p1' }, body: { name: 'High Wizard', description: '', modifiers: {} } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await professionController.update(req, res);
+
+      expect(Profession.findByIdAndUpdate).toHaveBeenCalledWith(
+        'p1',
+        { $set: { name: 'High Wizard', code: 'high_wizard', description: '', modifiers: {} } },
+        { new: true }
+      );
+    });
+
+    it('returns 400 when profession already exists', async () => {
+      Profession.findOne.mockResolvedValue({ _id: 'other' });
+
+      const req = { params: { id: 'p1' }, body: { name: 'Wizard', code: 'wizard' } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await professionController.update(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Profession already exists' });
     });
   });
 });

--- a/backend/tests/raceController.test.js
+++ b/backend/tests/raceController.test.js
@@ -15,6 +15,7 @@ describe('Race Controller', () => {
         instance = { save: jest.fn().mockResolvedValue(data) };
         return instance;
       });
+      Race.findOne.mockResolvedValue(null);
 
       const req = { body: { name: 'Elf', code: 'elf', description: '', modifiers: { agility: 1 } } };
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -27,10 +28,42 @@ describe('Race Controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith(instance);
     });
+
+    it('derives code from name when missing', async () => {
+      let instance;
+      Race.mockImplementation(data => {
+        instance = { save: jest.fn().mockResolvedValue(data) };
+        return instance;
+      });
+      Race.findOne.mockResolvedValue(null);
+
+      const req = { body: { name: 'Dark Elf', description: '', modifiers: {} } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await raceController.create(req, res);
+
+      expect(Race).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'dark_elf' })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 400 when race already exists', async () => {
+      Race.findOne.mockResolvedValue({ _id: 'r2' });
+
+      const req = { body: { name: 'Elf', code: 'elf' } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await raceController.create(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Race already exists' });
+    });
   });
 
   describe('update', () => {
     it('updates modifiers field', async () => {
+      Race.findOne.mockResolvedValue(null);
       Race.findByIdAndUpdate.mockResolvedValue({ _id: 'r1', modifiers: { agility: 2 } });
 
       const req = { params: { id: 'r1' }, body: { name: 'Elf', code: 'elf', description: '', modifiers: { agility: 2 } } };
@@ -44,6 +77,34 @@ describe('Race Controller', () => {
         { new: true }
       );
       expect(res.json).toHaveBeenCalledWith({ _id: 'r1', modifiers: { agility: 2 } });
+    });
+
+    it('derives code from name when missing', async () => {
+      Race.findOne.mockResolvedValue(null);
+      Race.findByIdAndUpdate.mockResolvedValue({ _id: 'r1' });
+
+      const req = { params: { id: 'r1' }, body: { name: 'Dark Elf', description: '', modifiers: {} } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await raceController.update(req, res);
+
+      expect(Race.findByIdAndUpdate).toHaveBeenCalledWith(
+        'r1',
+        { $set: { name: 'Dark Elf', code: 'dark_elf', description: '', modifiers: {} } },
+        { new: true }
+      );
+    });
+
+    it('returns 400 when race already exists', async () => {
+      Race.findOne.mockResolvedValue({ _id: 'x' });
+
+      const req = { params: { id: 'r1' }, body: { name: 'Elf', code: 'elf' } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await raceController.update(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Race already exists' });
     });
   });
 });


### PR DESCRIPTION
## Summary
- auto-generate `code` with `slugify` in race and profession controllers
- avoid duplicates when creating or updating races and professions
- test slug generation and duplicate validation

## Testing
- `bash setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebc0547648322903605807a3121c6