### PR TITLE
Ensure starting sets generated for all combos

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -240,33 +240,51 @@ async function seed() {
   };
 
   if (await StartingSet.countDocuments() === 0) {
-    const inventorySets = {};
+    const sets = [];
+    const skipped = [];
+
     for (const race of races) {
-      inventorySets[race.code] = {};
-      for (const [cls, groups] of Object.entries(classInventory)) {
+      for (const profession of professions) {
+        const groups = classInventory[profession.code];
+        if (!groups) {
+          skipped.push(`${race.code}/${profession.code}`);
+          continue;
+        }
+
         const arrays = Object.values(groups)
           .filter(a => a.length)
           .map(a => a.map(d => d.item));
-        const combos = combine(arrays).slice(0, 3);
-        inventorySets[race.code][cls] = combos;
-      }
-    }
 
-    const sets = [];
-    for (const [raceCode, classes] of Object.entries(inventorySets)) {
-      for (const [cls, combos] of Object.entries(classes)) {
+        if (!arrays.length) {
+          skipped.push(`${race.code}/${profession.code}`);
+          continue;
+        }
+
+        const combos = combine(arrays).slice(0, 3);
+        if (combos.length === 0) {
+          skipped.push(`${race.code}/${profession.code}`);
+          continue;
+        }
+
         for (const combo of combos) {
           sets.push({
-            raceCode,
-            classCode: cls.toLowerCase(),
+            raceCode: race.code,
+            classCode: profession.code,
             items: combo.map(name => itemsByName[name])
           });
         }
       }
     }
+
     if (sets.length) {
       await StartingSet.insertMany(sets);
       console.log('Starting sets seeded');
+    }
+
+    if (skipped.length) {
+      for (const combo of skipped) {
+        console.warn(`Skipped starting set for ${combo}`);
+      }
     }
   }
 

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -37,4 +37,11 @@ describe('seed script', () => {
 
     }
   });
+
+  it('creates the correct total number of sets', async () => {
+    const raceCount = 6;
+    const classCount = 7;
+    const total = await StartingSet.countDocuments();
+    expect(total).toBe(raceCount * classCount * 3);
+  });
 });


### PR DESCRIPTION
## Summary
- seed starting sets for every race/profession pair
- log skipped combinations during seeding
- verify total count of starting sets in tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685ec0fb8b2c8322bdacda910b76a25d