### PR TITLE
Improve empty inventory warnings

### DIFF
--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -129,8 +129,12 @@ exports.create = async (req, res) => {
 
     const inventory = await generateInventory(raceCodeRaw, classCodeLower);
     if (!inventory.length) {
-      console.warn(`Empty inventory for race ${raceCodeRaw} class ${classCodeLower}`);
-      return res.status(400).json({ error: 'Missing starting items' });
+      console.warn(
+        `Empty inventory for race '${raceCodeRaw}' and class '${classCodeLower}'`
+      );
+      return res.status(400).json({
+        error: `Missing starting items for race '${raceCodeRaw}' and class '${classCodeLower}'`
+      });
     }
 
     const avatarUrl = await generateCharacterImage(

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -161,7 +161,9 @@ function generateInventory(raceCode, classCode) {
   }
 
   if (!result.length) {
-    console.warn(`No inventory generated for race ${raceCode} and class ${classCode}`);
+    console.warn(
+      `generateInventory() returned empty array for race '${raceCode}' and class '${classCode}'`
+    );
   }
 
   return result;

--- a/backend/tests/character.test.js
+++ b/backend/tests/character.test.js
@@ -358,7 +358,12 @@ describe('Character Controller - create', () => {
     await characterController.create(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Missing starting items' });
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Missing starting items for race 'orc' and class 'warrior'"
+    });
+    expect(console.warn).toHaveBeenCalledWith(
+      "Empty inventory for race 'orc' and class 'warrior'"
+    );
   });
 
 });


### PR DESCRIPTION
## Summary
- log race and class codes when generateInventory fails
- clarify error message for missing starting items
- test empty inventory handling in character controller

## Testing
- `./setup.sh`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ec0fd0a2c832286e23029c3403686