### PR TITLE
Handle image generation failures

### DIFF
--- a/backend/src/utils/ai.js
+++ b/backend/src/utils/ai.js
@@ -30,25 +30,32 @@ exports.generateCharacterImage = async (race, profession, gender) => {
   }
 
   // Example integration with a remote AI service (e.g. DALL-E or Stable Diffusion)
-  const res = await fetch('https://api.openai.com/v1/images/generations', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ prompt, n: 1, size: '512x512' }),
-  });
-  const data = await res.json();
-  const url = data.data?.[0]?.url;
-  if (!url) return '';
+  try {
+    const res = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ prompt, n: 1, size: '512x512' }),
+    });
+    const data = await res.json();
+    const url = data.data?.[0]?.url;
+    if (!url) return '';
 
-  // Download and persist the generated image
-  const imgRes = await fetch(url);
-  if (!imgRes.ok) return '';
-  const buffer = await imgRes.buffer();
-  const dir = path.join(__dirname, '..', '..', 'uploads', 'avatars');
-  fs.mkdirSync(dir, { recursive: true });
-  const filename = Date.now() + '.png';
-  fs.writeFileSync(path.join(dir, filename), buffer);
-  return `/uploads/avatars/${filename}`;
+    // Download and persist the generated image
+    const imgRes = await fetch(url);
+    if (!imgRes.ok) return '';
+    const buffer = await imgRes.buffer();
+    const dir = path.join(__dirname, '..', '..', 'uploads', 'avatars');
+    fs.mkdirSync(dir, { recursive: true });
+    const filename = Date.now() + '.png';
+    fs.writeFileSync(path.join(dir, filename), buffer);
+    return `/uploads/avatars/${filename}`;
+  } catch (err) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('Error generating character image:', err);
+    }
+    return '';
+  }
 };

--- a/backend/tests/ai.fetchError.test.js
+++ b/backend/tests/ai.fetchError.test.js
@@ -1,0 +1,26 @@
+jest.mock('node-fetch', () => jest.fn());
+
+let generateCharacterImage;
+let fetch;
+
+describe('generateCharacterImage fetch failure', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.OPENAI_API_KEY = 'key';
+    fetch = require('node-fetch');
+    generateCharacterImage = require('../src/utils/ai').generateCharacterImage;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('resolves to empty string when fetch throws', async () => {
+    fetch.mockRejectedValue(new Error('fail'));
+
+    const result = await generateCharacterImage('elf', 'wizard', 'male');
+    expect(result).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- catch errors in `generateCharacterImage`
- log fetch errors in development and return an empty string
- test failure case for `generateCharacterImage`

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_685ec2ceadac832290b2151ee0727a02