### PR TITLE
Centralize inventory templates

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -10,6 +10,7 @@ const StartingSet = require('../src/models/StartingSet');
 const bcrypt = require('bcrypt');
 
 const slug = require('../src/utils/slugify');
+const { classInventory, raceInventory } = require('../src/data/staticInventoryTemplates');
 
 const MONGO_URI = process.env.MONGO_URI;
 
@@ -78,107 +79,6 @@ async function seed() {
     'mp'
   ];
 
-  const classInventory = {
-    warrior: {
-      weapon: [
-        { item: 'Меч', bonus: { strength: 2 } },
-        { item: 'Сокира', bonus: { strength: 2 } }
-      ],
-      armor: [
-        { item: 'Щит', bonus: { defense: 1 } },
-        { item: 'Шкіряна броня', bonus: { agility: 1 } }
-      ],
-      misc: [
-        { item: 'Зілля здоров’я' }
-      ]
-    },
-    wizard: {
-      weapon: [
-        { item: 'Магічний посох', bonus: { intellect: 2 } },
-        { item: 'Чарівна паличка', bonus: { intellect: 1 } }
-      ],
-      armor: [
-        { item: 'Обруч мудрості', bonus: { intellect: 1 } },
-        { item: 'Тканинна мантія', bonus: { health: 1 } }
-      ],
-      misc: [
-        { item: 'Мана-зілля' },
-        { item: 'Книга заклять' }
-      ]
-    },
-    assassin: {
-      weapon: [
-        { item: 'Лук', bonus: { agility: 1 } },
-        { item: 'Арбалет', bonus: { agility: 1 } }
-      ],
-      armor: [
-        { item: 'Шкіряна броня', bonus: { agility: 1 } },
-        { item: 'Ніж для виживання' }
-      ],
-      misc: [
-        { item: 'Колчан стріл' }
-      ]
-    },
-    bard: {
-      weapon: [
-        { item: 'Лютня', bonus: { charisma: 1 } },
-        { item: 'Легкий меч', bonus: { agility: 1 } }
-      ],
-      armor: [
-        { item: 'Короткий лук', bonus: { agility: 1 } },
-        { item: 'Пісенник' }
-      ],
-      misc: []
-    },
-    paladin: {
-      weapon: [
-        { item: 'Молот', bonus: { strength: 1 } },
-        { item: 'Святий меч', bonus: { strength: 2 } }
-      ],
-      armor: [
-        { item: 'Латна броня', bonus: { health: 2 } },
-        { item: 'Святий щит', bonus: { charisma: 1 } }
-      ],
-      misc: [
-        { item: 'Святий амулет' }
-      ]
-    },
-    archer: {
-      weapon: [
-        { item: 'Довгий лук', bonus: { agility: 2 } },
-        { item: 'Арбалет', bonus: { agility: 1 } }
-      ],
-      armor: [
-        { item: 'Шкіряна броня', bonus: { agility: 1 } },
-        { item: 'Капюшон мисливця' }
-      ],
-      misc: [
-        { item: 'Колчан стріл' }
-      ]
-    },
-    healer: {
-      weapon: [
-        { item: 'Жезл зцілення', bonus: { intellect: 1 } },
-        { item: 'Святий символ', bonus: { mp: 1 } }
-      ],
-      armor: [
-        { item: 'Ряса', bonus: { health: 1 } },
-        { item: 'Талісман віри', bonus: { charisma: 1 } }
-      ],
-      misc: [
-        { item: 'Зілля лікування' }
-      ]
-    }
-  };
-
-  const raceInventory = {
-    human: [{ item: 'Монета удачі', bonus: { charisma: 1 } }],
-    forest_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
-    dark_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
-    orc: [{ item: 'Кістяний талісман', bonus: { strength: 1 } }],
-    gnome: [{ item: 'Гвинтовий ключ' }],
-    dwarf: [{ item: 'Похідна кружка', bonus: { health: 1 } }]
-  };
 
   if (await Race.countDocuments() === 0) {
     await Race.insertMany(races);

--- a/backend/src/data/staticInventoryTemplates.js
+++ b/backend/src/data/staticInventoryTemplates.js
@@ -1,0 +1,103 @@
+const classInventory = {
+  warrior: {
+    weapon: [
+      { item: 'Меч', bonus: { strength: 2 } },
+      { item: 'Сокира', bonus: { strength: 2 } }
+    ],
+    armor: [
+      { item: 'Щит', bonus: { defense: 1 } },
+      { item: 'Шкіряна броня', bonus: { agility: 1 } }
+    ],
+    misc: [
+      { item: 'Зілля здоров’я' }
+    ]
+  },
+  wizard: {
+    weapon: [
+      { item: 'Магічний посох', bonus: { intellect: 2 } },
+      { item: 'Чарівна паличка', bonus: { intellect: 1 } }
+    ],
+    armor: [
+      { item: 'Обруч мудрості', bonus: { intellect: 1 } },
+      { item: 'Тканинна мантія', bonus: { health: 1 } }
+    ],
+    misc: [
+      { item: 'Мана-зілля' },
+      { item: 'Книга заклять' }
+    ]
+  },
+  assassin: {
+    weapon: [
+      { item: 'Лук', bonus: { agility: 1 } },
+      { item: 'Арбалет', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Шкіряна броня', bonus: { agility: 1 } },
+      { item: 'Ніж для виживання' }
+    ],
+    misc: [
+      { item: 'Колчан стріл' }
+    ]
+  },
+  bard: {
+    weapon: [
+      { item: 'Лютня', bonus: { charisma: 1 } },
+      { item: 'Легкий меч', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Короткий лук', bonus: { agility: 1 } },
+      { item: 'Пісенник' }
+    ],
+    misc: []
+  },
+  paladin: {
+    weapon: [
+      { item: 'Молот', bonus: { strength: 1 } },
+      { item: 'Святий меч', bonus: { strength: 2 } }
+    ],
+    armor: [
+      { item: 'Латна броня', bonus: { health: 2 } },
+      { item: 'Святий щит', bonus: { charisma: 1 } }
+    ],
+    misc: [
+      { item: 'Святий амулет' }
+    ]
+  },
+  archer: {
+    weapon: [
+      { item: 'Довгий лук', bonus: { agility: 2 } },
+      { item: 'Арбалет', bonus: { agility: 1 } }
+    ],
+    armor: [
+      { item: 'Шкіряна броня', bonus: { agility: 1 } },
+      { item: 'Капюшон мисливця' }
+    ],
+    misc: [
+      { item: 'Колчан стріл' }
+    ]
+  },
+  healer: {
+    weapon: [
+      { item: 'Жезл зцілення', bonus: { intellect: 1 } },
+      { item: 'Святий символ', bonus: { mp: 1 } }
+    ],
+    armor: [
+      { item: 'Ряса', bonus: { health: 1 } },
+      { item: 'Талісман віри', bonus: { charisma: 1 } }
+    ],
+    misc: [
+      { item: 'Зілля лікування' }
+    ]
+  }
+};
+
+const raceInventory = {
+  human: [{ item: 'Монета удачі', bonus: { charisma: 1 } }],
+  forest_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
+  dark_elf: [{ item: 'Ельфійські стріли', bonus: { agility: 1 } }],
+  orc: [{ item: 'Кістяний талісман', bonus: { strength: 1 } }],
+  gnome: [{ item: 'Гвинтовий ключ' }],
+  dwarf: [{ item: 'Похідна кружка', bonus: { health: 1 } }]
+};
+
+module.exports = { classInventory, raceInventory };

--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,98 +1,7 @@
 
 const slug = require('./slugify');
+const { classInventory, raceInventory } = require('../data/staticInventoryTemplates');
 
-const classInventory = {
-  warrior: {
-    weapon: [
-      { item: 'Меч', bonus: { strength: 2 } },
-      { item: 'Сокира', bonus: { strength: 2 } }
-    ],
-    armor: [
-      { item: 'Щит', bonus: { defense: 1 } },
-      { item: 'Шкіряна броня', bonus: { agility: 1 } }
-    ],
-    misc: [
-      { item: 'Зілля здоров’я' }
-    ]
-  },
-  wizard: {
-    weapon: [
-      { item: 'Магічний посох', bonus: { intellect: 2 } },
-      { item: 'Чарівна паличка', bonus: { intellect: 1 } }
-    ],
-    armor: [
-      { item: 'Обруч мудрості', bonus: { intellect: 1 } },
-      { item: 'Тканинна мантія', bonus: { health: 1 } }
-    ],
-    misc: [
-      { item: 'Мана-зілля' },
-      { item: 'Книга заклять' }
-    ]
-  },
-  assassin: {
-    weapon: [
-      { item: 'Лук', bonus: { agility: 1 } },
-      { item: 'Арбалет', bonus: { agility: 1 } }
-    ],
-    armor: [
-      { item: 'Шкіряна броня', bonus: { agility: 1 } },
-      { item: 'Ніж для виживання' }
-    ],
-    misc: [
-      { item: 'Колчан стріл' }
-    ]
-  },
-  bard: {
-    weapon: [
-      { item: 'Лютня', bonus: { charisma: 1 } },
-      { item: 'Легкий меч', bonus: { agility: 1 } }
-    ],
-    armor: [
-      { item: 'Короткий лук', bonus: { agility: 1 } },
-      { item: 'Пісенник' }
-    ],
-    misc: []
-  },
-  paladin: {
-    weapon: [
-      { item: 'Молот', bonus: { strength: 1 } },
-      { item: 'Святий меч', bonus: { strength: 2 } }
-    ],
-    armor: [
-      { item: 'Латна броня', bonus: { health: 2 } },
-      { item: 'Святий щит', bonus: { charisma: 1 } }
-    ],
-    misc: [
-      { item: 'Святий амулет' }
-    ]
-  },
-  archer: {
-    weapon: [
-      { item: 'Довгий лук', bonus: { agility: 2 } },
-      { item: 'Арбалет', bonus: { agility: 1 } }
-    ],
-    armor: [
-      { item: 'Шкіряна броня', bonus: { agility: 1 } },
-      { item: 'Капюшон мисливця' }
-    ],
-    misc: [
-      { item: 'Колчан стріл' }
-    ]
-  },
-  healer: {
-    weapon: [
-      { item: 'Жезл зцілення', bonus: { intellect: 1 } },
-      { item: 'Святий символ', bonus: { mp: 1 } }
-    ],
-    armor: [
-      { item: 'Ряса', bonus: { health: 1 } },
-      { item: 'Талісман віри', bonus: { charisma: 1 } }
-    ],
-    misc: [
-      { item: 'Зілля лікування' }
-    ]
-  }
-};
 
 function combine(arrays) {
   if (!arrays.length) return [[]];
@@ -120,14 +29,6 @@ for (const [cls, groups] of Object.entries(classInventory)) {
   }
 }
 
-const raceInventory = {
-  human: [{ item: 'Монета удачі', amount: 1, bonus: { charisma: 1 } }],
-  forest_elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
-  dark_elf: [{ item: 'Ельфійські стріли', amount: 1, bonus: { agility: 1 } }],
-  orc: [{ item: 'Кістяний талісман', amount: 1, bonus: { strength: 1 } }],
-  gnome: [{ item: 'Гвинтовий ключ', amount: 1 }],
-  dwarf: [{ item: 'Похідна кружка', amount: 1, bonus: { health: 1 } }]
-};
 
 function randomItem(list) {
   return list[Math.floor(Math.random() * list.length)];

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,4 +1,5 @@
 const generateInventory = require('../src/utils/generateInventory');
+const { raceInventory } = require('../src/data/staticInventoryTemplates');
 
 describe('generateInventory', () => {
   it('selects random items for each category', () => {
@@ -11,7 +12,7 @@ describe('generateInventory', () => {
       { item: 'Меч', code: 'меч', amount: 1, bonus: { strength: 2 } },
       { item: 'Щит', code: 'щит', amount: 1, bonus: { defense: 1 } },
       { item: 'Зілля здоров’я', code: 'зілля_здоров’я', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+      { item: raceInventory.orc[0].item, code: 'кістяний_талісман', amount: 1, bonus: raceInventory.orc[0].bonus }
     ]);
   });
 
@@ -25,7 +26,7 @@ describe('generateInventory', () => {
       { item: 'Меч', code: 'меч', amount: 1, bonus: { strength: 2 } },
       { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: { agility: 1 } },
       { item: 'Зілля здоров’я', code: 'зілля_здоров’я', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+      { item: raceInventory.orc[0].item, code: 'кістяний_талісман', amount: 1, bonus: raceInventory.orc[0].bonus }
     ]);
   });
 
@@ -39,7 +40,7 @@ describe('generateInventory', () => {
       { item: 'Довгий лук', code: 'довгий_лук', amount: 1, bonus: { agility: 2 } },
       { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: { agility: 1 } },
       { item: 'Колчан стріл', code: 'колчан_стріл', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+      { item: raceInventory.orc[0].item, code: 'кістяний_талісман', amount: 1, bonus: raceInventory.orc[0].bonus }
     ]);
   });
 
@@ -53,7 +54,7 @@ describe('generateInventory', () => {
       { item: 'Жезл зцілення', code: 'жезл_зцілення', amount: 1, bonus: { intellect: 1 } },
       { item: 'Ряса', code: 'ряса', amount: 1, bonus: { health: 1 } },
       { item: 'Зілля лікування', code: 'зілля_лікування', amount: 1, bonus: {} },
-      { item: 'Кістяний талісман', code: 'кістяний_талісман', amount: 1, bonus: { strength: 1 } }
+      { item: raceInventory.orc[0].item, code: 'кістяний_талісман', amount: 1, bonus: raceInventory.orc[0].bonus }
     ]);
   });
 

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const StartingSet = require('../src/models/StartingSet');
+const { classInventory, raceInventory } = require('../src/data/staticInventoryTemplates');
 
 jest.setTimeout(30000);
 
@@ -25,10 +26,8 @@ describe('seed script', () => {
 
 
   it('creates three sets for each race and class combination', async () => {
-    const races = [
-      'human','forest_elf','dark_elf','gnome','dwarf','orc'
-    ];
-    const classes = ['warrior','wizard','assassin','paladin','bard','archer','healer'];
+    const races = Object.keys(raceInventory);
+    const classes = Object.keys(classInventory);
     for (const r of races) {
       for (const c of classes) {
         const count = await StartingSet.countDocuments({ raceCode: r, classCode: c });


### PR DESCRIPTION
## Summary
- move inventory templates into `backend/src/data/staticInventoryTemplates.js`
- import the shared templates in `generateInventory.js` and `seed.js`
- adapt tests to use the shared templates

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685ec2d064788322929087e0c0c72dfe