### PR TITLE
Add class colors for additional professions

### DIFF
--- a/frontend/src/utils/classColors.js
+++ b/frontend/src/utils/classColors.js
@@ -7,6 +7,9 @@ export function getClassBorderColor(profession) {
     healer: 'border-teal-600',
     wizard: 'border-indigo-600',
     assassin: 'border-gray-600',
+    rogue: 'border-orange-600',
+    druid: 'border-lime-600',
+    necromancer: 'border-stone-600',
   };
   const key = (profession || '').toLowerCase();
   if (!key) return 'border-dndgold';


### PR DESCRIPTION
## Summary
- extend class color map with rogue, druid and necromancer

## Testing
- `npm run lint` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68604efbe9c48322bd47bff8db93bd86