### PR TITLE
Fix duplicate require in generateInventory

### DIFF
--- a/backend/src/utils/generateInventory.js
+++ b/backend/src/utils/generateInventory.js
@@ -1,7 +1,6 @@
 
 const StartingSet = require('../models/StartingSet');
 const slug = require('./slugify');
-const StartingSet = require('../models/StartingSet');
 const { classInventory, raceInventory } = require('../data/staticInventoryTemplates');
 
 


### PR DESCRIPTION
## Summary
- remove redundant `StartingSet` import in `generateInventory.js`

## Testing
- `npm test` in `backend` *(fails: ReferenceError in generateInventory tests)*

------
https://chatgpt.com/codex/tasks/task_e_68605c7d37b48322a52a5f752cb355c3