### PR TITLE
Fix tests for static inventory

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -116,10 +116,11 @@ async function seed() {
   }
 
   const addItem = (map, def, type) => {
-    if (!map.has(def.item)) {
-      map.set(def.item, {
+    const key = slug(def.item);
+    if (!map.has(key)) {
+      map.set(key, {
         name: def.item,
-        code: slug(def.item),
+        code: key,
         type,
         bonuses: def.bonus || {}
       });

--- a/backend/tests/generateInventory.test.js
+++ b/backend/tests/generateInventory.test.js
@@ -1,5 +1,6 @@
 const StartingSet = require('../src/models/StartingSet');
 const generateInventory = require('../src/utils/generateInventory');
+const { raceInventory } = require('../src/data/staticInventoryTemplates');
 
 jest.mock('../src/models/StartingSet');
 
@@ -43,9 +44,9 @@ describe('generateInventory', () => {
 
 
     expect(items).toEqual([
-      { item: 'Меч', code: 'меч', amount: 1, bonus: { strength: 2 } },
-      { item: 'Щит', code: 'щит', amount: 1, bonus: { defense: 1 } },
-      { item: 'Зілля здоров’я', code: 'зілля_здоров’я', amount: 1, bonus: {} },
+      { item: 'Довгий лук', code: 'довгий_лук', amount: 1, bonus: { agility: 2 } },
+      { item: 'Шкіряна броня', code: 'шкіряна_броня', amount: 1, bonus: { agility: 1 } },
+      { item: 'Колчан стріл', code: 'колчан_стріл', amount: 1, bonus: {} },
 
       { item: raceInventory.orc[0].item, code: 'кістяний_талісман', amount: 1, bonus: raceInventory.orc[0].bonus }
 


### PR DESCRIPTION
## Summary
- include `raceInventory` in generateInventory test
- correct expected fallback inventory values
- prevent duplicate items during seeding

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68606216e2d483228ec798cc9405b00c